### PR TITLE
Specify an optional list of MAC addresses to assign on new VMWare instances

### DIFF
--- a/infrastructures/infrastructure-aws-ec2/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/AWSEC2Infrastructure.java
+++ b/infrastructures/infrastructure-aws-ec2/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/AWSEC2Infrastructure.java
@@ -217,12 +217,13 @@ public class AWSEC2Infrastructure extends InfrastructureManager {
 
         Set<String> instancesIds = Sets.newHashSet();
 
+        // MAC addresses not yet managed
         if (spotPrice.isEmpty() && securityGroupNames.isEmpty() && subnetId.isEmpty()) {
             instancesIds = connectorIaasController.createInstances(getInfrastructureId(), instanceTag, image,
                     numberOfInstances, cores, ram);
         } else {
             instancesIds = connectorIaasController.createInstancesWithOptions(getInfrastructureId(),
-                    instanceTag, image, numberOfInstances, cores, ram, spotPrice, securityGroupNames, subnetId);
+                    instanceTag, image, numberOfInstances, cores, ram, spotPrice, securityGroupNames, subnetId, null);
         }
 
         for (String instanceId : instancesIds) {

--- a/infrastructures/infrastructure-aws-ec2/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/AWSEC2Infrastructure.java
+++ b/infrastructures/infrastructure-aws-ec2/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/AWSEC2Infrastructure.java
@@ -217,7 +217,6 @@ public class AWSEC2Infrastructure extends InfrastructureManager {
 
         Set<String> instancesIds = Sets.newHashSet();
 
-        // MAC addresses not yet managed
         if (spotPrice.isEmpty() && securityGroupNames.isEmpty() && subnetId.isEmpty()) {
             instancesIds = connectorIaasController.createInstances(getInfrastructureId(), instanceTag, image,
                     numberOfInstances, cores, ram);

--- a/infrastructures/infrastructure-aws-ec2/src/test/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/AWSEC2InfrastructureTest.java
+++ b/infrastructures/infrastructure-aws-ec2/src/test/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/AWSEC2InfrastructureTest.java
@@ -109,7 +109,7 @@ public class AWSEC2InfrastructureTest {
                 null, true)).thenReturn("node_source_name");
 
         when(connectorIaasController.createInstancesWithOptions("node_source_name", "node_source_name",
-                "aws-image", 2, 1, 512, "0.05", "default","127.0.0.1")).thenReturn(Sets.newHashSet("123", "456"));
+                "aws-image", 2, 1, 512, "0.05", "default","127.0.0.1", null)).thenReturn(Sets.newHashSet("123", "456"));
 
         awsec2Infrastructure.acquireNode();
 
@@ -119,7 +119,7 @@ public class AWSEC2InfrastructureTest {
                 null, false);
 
         verify(connectorIaasController).createInstancesWithOptions("node_source_name", "node_source_name",
-                "aws-image", 2, 1, 512, "0.05", "default","127.0.0.1");
+                "aws-image", 2, 1, 512, "0.05", "default","127.0.0.1", null);
 
         verify(connectorIaasController, times(2)).executeScript(anyString(), anyString(), anyList());
 

--- a/infrastructures/infrastructure-common/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/ConnectorIaasController.java
+++ b/infrastructures/infrastructure-common/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/ConnectorIaasController.java
@@ -47,10 +47,10 @@ public class ConnectorIaasController {
     }
 
     public Set<String> createInstancesWithOptions(String infrastructureId, String instanceTag, String image,
-            int numberOfInstances, int cores, int ram, String spotPrice, String securityGroupNames, String subnetId) {
+            int numberOfInstances, int cores, int ram, String spotPrice, String securityGroupNames, String subnetId, String macAddresses) {
 
         String instanceJson = ConnectorIaasJSONTransformer.getInstanceJSON(instanceTag, image,
-                "" + numberOfInstances, "" + cores, "" + ram, spotPrice, securityGroupNames, subnetId);
+                "" + numberOfInstances, "" + cores, "" + ram, spotPrice, securityGroupNames, subnetId, macAddresses);
 
         return createInstance(infrastructureId, instanceTag, instanceJson);
     }
@@ -59,7 +59,7 @@ public class ConnectorIaasController {
             int numberOfInstances, int cores, int ram) {
 
         String instanceJson = ConnectorIaasJSONTransformer.getInstanceJSON(instanceTag, image,
-                "" + numberOfInstances, "" + cores, "" + ram, null, null, null);
+                "" + numberOfInstances, "" + cores, "" + ram, null, null, null, null);
 
         return createInstance(infrastructureId, instanceTag, instanceJson);
     }

--- a/infrastructures/infrastructure-common/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/ConnectorIaasJSONTransformer.java
+++ b/infrastructures/infrastructure-common/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/ConnectorIaasJSONTransformer.java
@@ -30,7 +30,7 @@ public class ConnectorIaasJSONTransformer {
     }
 
     public static String getInstanceJSON(String tag, String image, String number, String cpu, String ram,
-            String spotPrice, String securityGroupNames, String subnetId) {
+            String spotPrice, String securityGroupNames, String subnetId, String macAddresses) {
         JSONObject hardware = new JSONObject();
         hardware.put("minCores", cpu);
         hardware.put("minRam", ram);
@@ -50,6 +50,16 @@ public class ConnectorIaasJSONTransformer {
         
         if (subnetId != null && !subnetId.isEmpty()) {
             options.put("subnetId", subnetId);
+        }
+         
+        if (macAddresses != null && !macAddresses.isEmpty()) {
+            /*JSONArray addresses = new JSONArray();
+            for (String address : macAddresses.split(",")) {
+                addresses.put(address);
+            }*/
+            String[] addresses = macAddresses.split(",");
+            Set<String> addressesSet = new HashSet<>(Arrays.asList(addresses));
+            options.put("macAddresses", addressesSet);
         }
         
         return new JSONObject().put("tag", tag).put("image", image).put("number", number)

--- a/infrastructures/infrastructure-common/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/ConnectorIaasJSONTransformer.java
+++ b/infrastructures/infrastructure-common/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/ConnectorIaasJSONTransformer.java
@@ -1,5 +1,6 @@
 package org.ow2.proactive.resourcemanager.nodesource.infrastructure;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
@@ -53,13 +54,9 @@ public class ConnectorIaasJSONTransformer {
         }
          
         if (macAddresses != null && !macAddresses.isEmpty()) {
-            /*JSONArray addresses = new JSONArray();
-            for (String address : macAddresses.split(",")) {
-                addresses.put(address);
-            }*/
             String[] addresses = macAddresses.split(",");
-            Set<String> addressesSet = new HashSet<>(Arrays.asList(addresses));
-            options.put("macAddresses", addressesSet);
+            List<String> addressesList = Arrays.asList(addresses);
+            options.put("macAddresses", addressesList);
         }
         
         return new JSONObject().put("tag", tag).put("image", image).put("number", number)

--- a/infrastructures/infrastructure-common/src/test/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/ConnectorIaasControllerTest.java
+++ b/infrastructures/infrastructure-common/src/test/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/ConnectorIaasControllerTest.java
@@ -80,7 +80,7 @@ public class ConnectorIaasControllerTest {
     public void testCreateInstances() {
 
         String instanceJson = ConnectorIaasJSONTransformer.getInstanceJSON("node_source_name", "image", "2",
-                "1", "512", "0.05", "default","127.0.0.1");
+                "1", "512", "0.05", "default","127.0.0.1", "00:50:56:11:11:11");
 
         Set<String> instanceIds = Sets.newHashSet("123", "456");
 
@@ -93,7 +93,8 @@ public class ConnectorIaasControllerTest {
                 .thenReturn(existingInstances);
 
         Set<String> instancesIds = connectorIaasController.createInstancesWithOptions("node_source_name",
-                "node_source_name", "image", 2, 1, 512, "0.05","default","127.0.0.1");
+                "node_source_name", "image", 2, 1, 512, "0.05",
+                "default","127.0.0.1", "00:50:56:11:11:11");
 
         assertThat(instancesIds.size(), is(2));
         assertThat(instancesIds.containsAll(instanceIds), is(true));
@@ -137,7 +138,7 @@ public class ConnectorIaasControllerTest {
     public void testCreateInstancesAlreadyExistent() {
 
         String instanceJson = ConnectorIaasJSONTransformer.getInstanceJSON("node_source_name", "image", "2",
-                "1", "512", null, null, null);
+                "1", "512", null, null, null, null);
 
         Set<String> instanceIds = Sets.newHashSet("123", "456");
 

--- a/infrastructures/infrastructure-common/src/test/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/ConnectorIaasJSONTransformerTest.java
+++ b/infrastructures/infrastructure-common/src/test/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/ConnectorIaasJSONTransformerTest.java
@@ -28,7 +28,7 @@ public class ConnectorIaasJSONTransformerTest {
     @Test
     public void testGetInstanceJSON() {
         JSONObject actual = new JSONObject(ConnectorIaasJSONTransformer.getInstanceJSON("tag", "image",
-                "number", "minCores", "minRam", null, null, null));
+                "number", "minCores", "minRam", null, null, null, null));
 
         assertThat(actual.getString("tag"), is("tag"));
         assertThat(actual.getString("image"), is("image"));
@@ -41,7 +41,8 @@ public class ConnectorIaasJSONTransformerTest {
     @Test
     public void testGetInstanceJSONWithSpotPrice() {
         JSONObject actual = new JSONObject(ConnectorIaasJSONTransformer.getInstanceJSON("tag", "image",
-                "number", "minCores", "minRam", "0.05", "default","127.0.0.1"));
+                "number", "minCores", "minRam", "0.05", "default",
+                "127.0.0.1", "00:50:56:11:11:11"));
 
         assertThat(actual.getString("tag"), is("tag"));
         assertThat(actual.getString("image"), is("image"));
@@ -49,6 +50,7 @@ public class ConnectorIaasJSONTransformerTest {
         assertThat(actual.getJSONObject("hardware").getString("minCores"), is("minCores"));
         assertThat(actual.getJSONObject("hardware").getString("minRam"), is("minRam"));
         assertThat(actual.getJSONObject("options").getString("spotPrice"), is("0.05"));
+        assertThat(actual.getJSONObject("options").getJSONArray("macAddresses").toString(), is("[\"00:50:56:11:11:11\"]"));
     }
 
     @Test

--- a/infrastructures/infrastructure-vmware/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/VMWareInfrastructure.java
+++ b/infrastructures/infrastructure-vmware/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/VMWareInfrastructure.java
@@ -219,7 +219,7 @@ public class VMWareInfrastructure extends InfrastructureManager {
 
         String instanceTag = getInfrastructureId();
         Set<String> instancesIds;
-        if (macAddresses != null) {
+        if (!macAddresses.isEmpty()) {
             instancesIds = connectorIaasController.createInstancesWithOptions(getInfrastructureId(), instanceTag, image,
                     numberOfInstances, cores, ram, null, null, null, macAddresses);
         } else {

--- a/infrastructures/infrastructure-vmware/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/VMWareInfrastructure.java
+++ b/infrastructures/infrastructure-vmware/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/VMWareInfrastructure.java
@@ -87,7 +87,7 @@ public class VMWareInfrastructure extends InfrastructureManager {
     @Configurable(description = "The virtual machine Username")
     protected String vmUsername = null;
 
-    @Configurable(description = "TThe virtual machine Password")
+    @Configurable(description = "The virtual machine Password")
     protected String vmPassword = null;
 
     @Configurable(description = "Total instance to create")
@@ -98,6 +98,9 @@ public class VMWareInfrastructure extends InfrastructureManager {
 
     @Configurable(description = "Command used to download the worker jar")
     protected String downloadCommand = generateDefaultDownloadCommand();
+
+    @Configurable(description = "Optional list of MAC addresses separated by comma ',' to assign on new cloned VMs (1 per instance)")
+    protected String macAddresses = null;
 
     @Configurable(description = "Additional Java command properties (e.g. \"-Dpropertyname=propertyvalue\")")
     protected String additionalProperties = "-Dproactive.useIPaddress=true";
@@ -132,7 +135,8 @@ public class VMWareInfrastructure extends InfrastructureManager {
         this.numberOfInstances = Integer.parseInt(parameters[10].toString().trim());
         this.numberOfNodesPerInstance = Integer.parseInt(parameters[11].toString().trim());
         this.downloadCommand = parameters[12].toString().trim();
-        this.additionalProperties = parameters[13].toString().trim();
+        this.macAddresses = parameters[13].toString().trim();
+        this.additionalProperties = parameters[14].toString().trim();
 
         connectorIaasController = new ConnectorIaasController(connectorIaasURL, INFRASTRUCTURE_TYPE);
 
@@ -199,6 +203,10 @@ public class VMWareInfrastructure extends InfrastructureManager {
         if (parameters[13] == null) {
             parameters[13] = "";
         }
+
+        if (parameters[14] == null) {
+            parameters[14] = "";
+        }
     }
 
     @Override
@@ -210,9 +218,15 @@ public class VMWareInfrastructure extends InfrastructureManager {
                 false);
 
         String instanceTag = getInfrastructureId();
+        Set<String> instancesIds;
+        if (macAddresses != null) {
+            instancesIds = connectorIaasController.createInstancesWithOptions(getInfrastructureId(), instanceTag, image,
+                    numberOfInstances, cores, ram, null, null, null, macAddresses);
+        } else {
 
-        Set<String> instancesIds = connectorIaasController.createInstances(getInfrastructureId(), instanceTag,
-                image, numberOfInstances, cores, ram);
+            instancesIds = connectorIaasController.createInstances(getInfrastructureId(), instanceTag,
+                    image, numberOfInstances, cores, ram);
+        }
 
         logger.info("Instances ids created : " + instancesIds);
 

--- a/infrastructures/infrastructure-vmware/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/VMWareInfrastructure.java
+++ b/infrastructures/infrastructure-vmware/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/VMWareInfrastructure.java
@@ -99,7 +99,7 @@ public class VMWareInfrastructure extends InfrastructureManager {
     @Configurable(description = "Command used to download the worker jar")
     protected String downloadCommand = generateDefaultDownloadCommand();
 
-    @Configurable(description = "Optional list of MAC addresses separated by comma ',' to assign on new cloned VMs (1 per instance)")
+    @Configurable(description = "Optional list of MAC addresses separated by comma ',' to assign on new cloned VMs")
     protected String macAddresses = null;
 
     @Configurable(description = "Additional Java command properties (e.g. \"-Dpropertyname=propertyvalue\")")

--- a/infrastructures/infrastructure-vmware/src/test/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/VMWareInfrastructureTest.java
+++ b/infrastructures/infrastructure-vmware/src/test/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/VMWareInfrastructureTest.java
@@ -70,6 +70,7 @@ public class VMWareInfrastructureTest {
 
         }
         assertThat(vmwareInfrastructure.additionalProperties, is("-Dproactive.useIPaddress=true"));
+        assertThat(vmwareInfrastructure.macAddresses, is(nullValue()));
 
     }
 
@@ -80,7 +81,7 @@ public class VMWareInfrastructureTest {
 
         vmwareInfrastructure.configure("username", "password", "endpoint", "test.activeeon.com",
                 "http://localhost:8088/connector-iaas", "vmware-image", "1", "512", "vmUsername",
-                "vmPassword", "2", "3", "wget -nv test.activeeon.com/rest/node.jar", "-Dnew=value");
+                "vmPassword", "2", "3", "wget -nv test.activeeon.com/rest/node.jar", "-Dnew=value", "00:50:56:11:11:11");
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -102,7 +103,7 @@ public class VMWareInfrastructureTest {
 
         vmwareInfrastructure.configure("username", "password", "endpoint", "test.activeeon.com",
                 "http://localhost:8088/connector-iaas", "vmware-image", "512", "1", "vmUsername",
-                "vmPassword", "1", "3", "wget -nv test.activeeon.com/rest/node.jar", "-Dnew=value");
+                "vmPassword", "1", "3", "wget -nv test.activeeon.com/rest/node.jar", "-Dnew=value", "00:50:56:11:11:11");
 
         vmwareInfrastructure.connectorIaasController = connectorIaasController;
 
@@ -140,7 +141,7 @@ public class VMWareInfrastructureTest {
 
         vmwareInfrastructure.configure("username", "password", "endpoint", "test.activeeon.com",
                 "http://localhost:8088/connector-iaas", "vmware-image", "1", "512", "vmUsername",
-                "vmPassword", "2", "3", "wget -nv test.activeeon.com/rest/node.jar", "-Dnew=value");
+                "vmPassword", "2", "3", "wget -nv test.activeeon.com/rest/node.jar", "-Dnew=value", "00:50:56:11:11:11");
 
         vmwareInfrastructure.connectorIaasController = connectorIaasController;
 
@@ -171,7 +172,7 @@ public class VMWareInfrastructureTest {
         vmwareInfrastructure.nodeSource = nodeSource;
         vmwareInfrastructure.configure("username", "password", "endpoint", "test.activeeon.com",
                 "http://localhost:8088/connector-iaas", "vmware-image", "1", "512", "vmUsername",
-                "vmPassword", "2", "3", "wget -nv test.activeeon.com/rest/node.jar", "-Dnew=value");
+                "vmPassword", "2", "3", "wget -nv test.activeeon.com/rest/node.jar", "-Dnew=value", "00:50:56:11:11:11");
 
         vmwareInfrastructure.connectorIaasController = connectorIaasController;
 

--- a/infrastructures/infrastructure-vmware/src/test/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/VMWareInfrastructureTest.java
+++ b/infrastructures/infrastructure-vmware/src/test/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/VMWareInfrastructureTest.java
@@ -81,7 +81,8 @@ public class VMWareInfrastructureTest {
 
         vmwareInfrastructure.configure("username", "password", "endpoint", "test.activeeon.com",
                 "http://localhost:8088/connector-iaas", "vmware-image", "1", "512", "vmUsername",
-                "vmPassword", "2", "3", "wget -nv test.activeeon.com/rest/node.jar", "-Dnew=value", "00:50:56:11:11:11");
+                "vmPassword", "2", "3", "wget -nv test.activeeon.com/rest/node.jar", "00:50:56:11:11:11",
+                "-Dnew=value");
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -92,7 +93,7 @@ public class VMWareInfrastructureTest {
 
         vmwareInfrastructure.configure("username", "password", "endpoint", "test.activeeon.com",
                 "http://localhost:8088/connector-iaas", "publicKeyName", "2", "3",
-                "wget -nv test.activeeon.com/rest/node.jar", "-Dnew=value");
+                "wget -nv test.activeeon.com/rest/node.jar", "00:50:56:11:11:11");
     }
 
     @Test
@@ -103,7 +104,7 @@ public class VMWareInfrastructureTest {
 
         vmwareInfrastructure.configure("username", "password", "endpoint", "test.activeeon.com",
                 "http://localhost:8088/connector-iaas", "vmware-image", "512", "1", "vmUsername",
-                "vmPassword", "1", "3", "wget -nv test.activeeon.com/rest/node.jar", "-Dnew=value", "00:50:56:11:11:11");
+                "vmPassword", "1", "3", "wget -nv test.activeeon.com/rest/node.jar", null, "-Dnew=value");
 
         vmwareInfrastructure.connectorIaasController = connectorIaasController;
 
@@ -130,6 +131,41 @@ public class VMWareInfrastructureTest {
     }
 
     @Test
+    public void testAcquireNodeWithOptions() {
+
+        when(nodeSource.getName()).thenReturn("Node source Name");
+        vmwareInfrastructure.nodeSource = nodeSource;
+
+        vmwareInfrastructure.configure("username", "password", "endpoint", "test.activeeon.com",
+                "http://localhost:8088/connector-iaas", "vmware-image", "512", "1", "vmUsername",
+                "vmPassword", "1", "3", "wget -nv test.activeeon.com/rest/node.jar", "00:50:56:11:11:11", "-Dnew=value");
+
+        vmwareInfrastructure.connectorIaasController = connectorIaasController;
+
+        vmwareInfrastructure.rmUrl = "http://test.activeeon.com";
+
+        when(connectorIaasController.createInfrastructure("node_source_name", "username", "password",
+                "endpoint", false)).thenReturn("node_source_name");
+
+        when(connectorIaasController.createInstancesWithOptions("node_source_name", "node_source_name",
+                "vmware-image", 1, 1, 512, null, null, null, "00:50:56:11:11:11"))
+                .thenReturn(Sets.newHashSet("123", "456"));
+
+        vmwareInfrastructure.acquireNode();
+
+        verify(connectorIaasController, times(1)).waitForConnectorIaasToBeUP();
+
+        verify(connectorIaasController).createInfrastructure("node_source_name", "username", "password",
+                "endpoint", false);
+
+        verify(connectorIaasController).createInstancesWithOptions("node_source_name", "node_source_name",
+                "vmware-image", 1, 1, 512, null, null, null, "00:50:56:11:11:11");
+
+        verify(connectorIaasController, times(2)).executeScriptWithCredentials(anyString(), anyString(),
+                anyList(), anyString(), anyString());
+    }
+
+    @Test
     public void testAcquireAllNodes() {
         testAcquireNode();
     }
@@ -141,7 +177,7 @@ public class VMWareInfrastructureTest {
 
         vmwareInfrastructure.configure("username", "password", "endpoint", "test.activeeon.com",
                 "http://localhost:8088/connector-iaas", "vmware-image", "1", "512", "vmUsername",
-                "vmPassword", "2", "3", "wget -nv test.activeeon.com/rest/node.jar", "-Dnew=value", "00:50:56:11:11:11");
+                "vmPassword", "2", "3", "wget -nv test.activeeon.com/rest/node.jar", "00:50:56:11:11:11", "-Dnew=value");
 
         vmwareInfrastructure.connectorIaasController = connectorIaasController;
 
@@ -172,7 +208,7 @@ public class VMWareInfrastructureTest {
         vmwareInfrastructure.nodeSource = nodeSource;
         vmwareInfrastructure.configure("username", "password", "endpoint", "test.activeeon.com",
                 "http://localhost:8088/connector-iaas", "vmware-image", "1", "512", "vmUsername",
-                "vmPassword", "2", "3", "wget -nv test.activeeon.com/rest/node.jar", "-Dnew=value", "00:50:56:11:11:11");
+                "vmPassword", "2", "3", "wget -nv test.activeeon.com/rest/node.jar", "00:50:56:11:11:11", "-Dnew=value");
 
         vmwareInfrastructure.connectorIaasController = connectorIaasController;
 


### PR DESCRIPTION
Informations:
 - Modifications triggered by the new MAC address feature from  ow2-proactive/connector-iaas#26
 - The new field is currently assigned to VMWare infrastructure only and is optional.
 - Multiple MAC addresses can be specified using ',' separator.