### PR TITLE
Update Azure NodeSource to run Windows VMs.

### DIFF
--- a/infrastructures/infrastructure-azure/src/test/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/AzureInfrastructureTest.java
+++ b/infrastructures/infrastructure-azure/src/test/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/AzureInfrastructureTest.java
@@ -92,9 +92,8 @@ public class AzureInfrastructureTest {
         assertThat(azureInfrastructure.managementEndpoint, is(nullValue()));
         assertThat(azureInfrastructure.resourceManagerEndpoint, is(nullValue()));
         assertThat(azureInfrastructure.graphEndpoint, is(nullValue()));
-        assertThat(azureInfrastructure.rmHostname, is(not(nullValue())));
-        assertThat(azureInfrastructure.connectorIaasURL,
-                   is("http://" + azureInfrastructure.rmHostname + ":8080/connector-iaas"));
+        assertThat(azureInfrastructure.rmHttpUrl, is(not(nullValue())));
+        assertThat(azureInfrastructure.connectorIaasURL, is(azureInfrastructure.rmHttpUrl + "/connector-iaas"));
         assertThat(azureInfrastructure.image, is(nullValue()));
         assertTrue(azureInfrastructure.imageOSType.equals("linux"));
         assertThat(azureInfrastructure.vmSizeType, is(nullValue()));
@@ -125,7 +124,7 @@ public class AzureInfrastructureTest {
                                           "managementEndpoint",
                                           "resourceManagerEndpoint",
                                           "graphEndpoint",
-                                          "test.activeeon.com",
+                                          "http://test.activeeon.com:8080",
                                           "http://localhost:8088/connector-iaas",
                                           "image",
                                           "linux",
@@ -170,7 +169,7 @@ public class AzureInfrastructureTest {
                                       "managementEndpoint",
                                       "resourceManagerEndpoint",
                                       "graphEndpoint",
-                                      "test.activeeon.com",
+                                      "http://test.activeeon.com:8080",
                                       "http://localhost:8088/connector-iaas",
                                       null,
                                       "linux",
@@ -203,7 +202,7 @@ public class AzureInfrastructureTest {
                                       "managementEndpoint",
                                       "resourceManagerEndpoint",
                                       "graphEndpoint",
-                                      "test.activeeon.com",
+                                      "http://test.activeeon.com:8080",
                                       "http://localhost:8088/connector-iaas",
                                       "image",
                                       "windows",
@@ -292,7 +291,7 @@ public class AzureInfrastructureTest {
                                       "managementEndpoint",
                                       "resourceManagerEndpoint",
                                       "graphEndpoint",
-                                      "test.activeeon.com",
+                                      "http://test.activeeon.com:8080",
                                       "http://localhost:8088/connector-iaas",
                                       "image",
                                       "linux",
@@ -344,7 +343,7 @@ public class AzureInfrastructureTest {
                                       "managementEndpoint",
                                       "resourceManagerEndpoint",
                                       "graphEndpoint",
-                                      "test.activeeon.com",
+                                      "http://test.activeeon.com:8080",
                                       "http://localhost:8088/connector-iaas",
                                       "image",
                                       "linux",

--- a/infrastructures/infrastructure-azure/src/test/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/AzureInfrastructureTest.java
+++ b/infrastructures/infrastructure-azure/src/test/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/AzureInfrastructureTest.java
@@ -29,6 +29,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.anyList;
 import static org.mockito.Matchers.anyString;
@@ -95,6 +96,7 @@ public class AzureInfrastructureTest {
         assertThat(azureInfrastructure.connectorIaasURL,
                    is("http://" + azureInfrastructure.rmHostname + ":8080/connector-iaas"));
         assertThat(azureInfrastructure.image, is(nullValue()));
+        assertTrue(azureInfrastructure.imageOSType.equals("linux"));
         assertThat(azureInfrastructure.vmSizeType, is(nullValue()));
         assertThat(azureInfrastructure.vmUsername, is(nullValue()));
         assertThat(azureInfrastructure.vmPassword, is(nullValue()));
@@ -103,15 +105,7 @@ public class AzureInfrastructureTest {
         assertThat(azureInfrastructure.region, is(nullValue()));
         assertThat(azureInfrastructure.numberOfInstances, is(1));
         assertThat(azureInfrastructure.numberOfNodesPerInstance, is(1));
-        if (System.getProperty("os.name").contains("Windows")) {
-            assertThat(azureInfrastructure.downloadCommand,
-                       is("powershell -command \"& { (New-Object Net.WebClient).DownloadFile('http://" +
-                          azureInfrastructure.rmHostname + ":8080/rest/node.jar', 'node.jar') }\""));
-        } else {
-            assertThat(azureInfrastructure.downloadCommand,
-                       is("wget -nv http://" + azureInfrastructure.rmHostname + ":8080/rest/node.jar"));
-
-        }
+        assertThat(azureInfrastructure.downloadCommand, is(nullValue()));
         assertThat(azureInfrastructure.privateNetworkCIDR, is(nullValue()));
         assertThat(azureInfrastructure.staticPublicIP, is(true));
         assertThat(azureInfrastructure.additionalProperties, is("-Dproactive.useIPaddress=true"));
@@ -134,6 +128,7 @@ public class AzureInfrastructureTest {
                                           "test.activeeon.com",
                                           "http://localhost:8088/connector-iaas",
                                           "image",
+                                          "linux",
                                           "Standard_D1_v2",
                                           "vmUsername",
                                           "vmPassword",
@@ -178,6 +173,7 @@ public class AzureInfrastructureTest {
                                       "test.activeeon.com",
                                       "http://localhost:8088/connector-iaas",
                                       null,
+                                      "linux",
                                       "Standard_D1_v2",
                                       "vmUsername",
                                       "vmPassword",
@@ -210,6 +206,7 @@ public class AzureInfrastructureTest {
                                       "test.activeeon.com",
                                       "http://localhost:8088/connector-iaas",
                                       "image",
+                                      "windows",
                                       "Standard_D1_v2",
                                       "vmUsername",
                                       "vmPassword",
@@ -218,7 +215,7 @@ public class AzureInfrastructureTest {
                                       "region",
                                       "2",
                                       "3",
-                                      "wget -nv test.activeeon.com/rest/node.jar",
+                                      null,
                                       "192.168.1.0/24",
                                       true,
                                       "-Dnew=value");
@@ -298,6 +295,7 @@ public class AzureInfrastructureTest {
                                       "test.activeeon.com",
                                       "http://localhost:8088/connector-iaas",
                                       "image",
+                                      "linux",
                                       "Standard_D1_v2",
                                       "vmUsername",
                                       "vmPassword",
@@ -349,6 +347,7 @@ public class AzureInfrastructureTest {
                                       "test.activeeon.com",
                                       "http://localhost:8088/connector-iaas",
                                       "image",
+                                      "linux",
                                       "Standard_D1_v2",
                                       "vmUsername",
                                       "vmPassword",

--- a/infrastructures/infrastructure-common/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/ConnectorIaasController.java
+++ b/infrastructures/infrastructure-common/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/ConnectorIaasController.java
@@ -234,14 +234,16 @@ public class ConnectorIaasController {
         String scriptResult = null;
         try {
 
+            logger.info("Trying to execute script for instance id:" + instanceId);
+
             scriptResult = connectorIaasClient.runScriptOnInstance(infrastructureId, instanceId, instanceScriptJson);
 
-            logger.info("Executed successfully script for instance id :" + instanceId);
-            logger.info("InstanceScriptJson : " + instanceScriptJson);
-            logger.info("Script result : " + scriptResult);
+            logger.info("Executed successfully script for instance id:" + instanceId);
+            logger.info("InstanceScriptJson: " + instanceScriptJson);
+            logger.info("Script result: " + scriptResult);
 
         } catch (Exception e) {
-            logger.error("Error while executing script :\n" + instanceScriptJson, e);
+            logger.error("Error while executing script:\n" + instanceScriptJson, e);
             throw new ScriptNotExecutedException(e);
         }
     }


### PR DESCRIPTION
- Works with latest connector-iaas upgrade only
- New 'imageOSType' property to indicate OS type of the image
- Resource group can retrieved from imageId
- Download command built internally and overridable in form
- Make scripts unique using UUIDs (may need to be replaced on
connector-iaas)