### PR TITLE
In AWSEC2Infrastructure, generate key pair whenever an info is missing

### DIFF
--- a/infrastructures/infrastructure-aws-ec2/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/AWSEC2Infrastructure.java
+++ b/infrastructures/infrastructure-aws-ec2/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/AWSEC2Infrastructure.java
@@ -312,7 +312,7 @@ public class AWSEC2Infrastructure extends AbstractAddonInfrastructure {
 
     private String createOrUseKeyPair(String infrastructureId) {
         SimpleImmutableEntry<String, String> keyPairInfo;
-        if (vmPrivateKey.length == 0) {
+        if (vmPrivateKey.length == 0 || vmKeyPairName.isEmpty()) {
             // create a key pair in AWS
             try {
                 logger.info("Creating an AWS key pair");
@@ -327,14 +327,9 @@ public class AWSEC2Infrastructure extends AbstractAddonInfrastructure {
                 keyPairInfo = handleKeyPairCreationFailure();
             }
         } else {
-            if (!vmKeyPairName.isEmpty()) {
-                // or use the private key provided by the user
-                logger.info("Using AWS key pair provided by the user");
-                keyPairInfo = new SimpleImmutableEntry<>(vmKeyPairName,
-                                                         new String(vmPrivateKey, StandardCharsets.UTF_8));
-            } else {
-                throw new IllegalArgumentException("When the private key is provided, the key pair name must be provided as well");
-            }
+            // or use the private key provided by the user
+            logger.info("Using AWS key pair provided by the user");
+            keyPairInfo = new SimpleImmutableEntry<>(vmKeyPairName, new String(vmPrivateKey, StandardCharsets.UTF_8));
         }
         persistKeyPairInfo(keyPairInfo);
 


### PR DESCRIPTION
- before we would generate a key pair only if both the key pair name and the private key were missing, otherwise we would fail. To allow more flexibility, we now generate a keypair whenever there is only one of these information missing.