### PR TITLE
Change charset encoding for private key in AWS infrastructure

### DIFF
--- a/infrastructures/infrastructure-aws-ec2/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/AWSEC2Infrastructure.java
+++ b/infrastructures/infrastructure-aws-ec2/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/AWSEC2Infrastructure.java
@@ -34,7 +34,6 @@ import java.util.AbstractMap.SimpleImmutableEntry;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.UUID;
 
 import org.apache.log4j.Logger;
 import org.objectweb.proactive.core.ProActiveException;
@@ -124,7 +123,7 @@ public class AWSEC2Infrastructure extends AbstractAddonInfrastructure {
         this.image = parameters[parameterIndex++].toString().trim();
         this.vmUsername = parameters[parameterIndex++].toString().trim();
         this.vmKeyPairName = parameters[parameterIndex++].toString().trim();
-        this.vmPrivateKey = parameters[parameterIndex++].toString().getBytes(StandardCharsets.UTF_8);
+        this.vmPrivateKey = (byte[]) parameters[parameterIndex++];
         this.numberOfInstances = Integer.parseInt(parameters[parameterIndex++].toString().trim());
         this.numberOfNodesPerInstance = Integer.parseInt(parameters[parameterIndex++].toString().trim());
         this.downloadCommand = parameters[parameterIndex++].toString().trim();
@@ -329,7 +328,8 @@ public class AWSEC2Infrastructure extends AbstractAddonInfrastructure {
         } else {
             // or use the private key provided by the user
             logger.info("Using AWS key pair provided by the user");
-            keyPairInfo = new SimpleImmutableEntry<>(vmKeyPairName, new String(vmPrivateKey, StandardCharsets.UTF_8));
+            keyPairInfo = new SimpleImmutableEntry<>(vmKeyPairName,
+                                                     new String(vmPrivateKey, StandardCharsets.ISO_8859_1));
         }
         persistKeyPairInfo(keyPairInfo);
 

--- a/infrastructures/infrastructure-aws-ec2/src/test/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/AWSEC2InfrastructureTest.java
+++ b/infrastructures/infrastructure-aws-ec2/src/test/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/AWSEC2InfrastructureTest.java
@@ -54,6 +54,8 @@ import org.python.google.common.collect.Sets;
 
 public class AWSEC2InfrastructureTest {
 
+    private static final byte[] PRIVATE_KEY = new byte[] { 0, 1, 2, 3, 4 };
+
     private AWSEC2Infrastructure awsec2Infrastructure;
 
     @Mock
@@ -126,7 +128,7 @@ public class AWSEC2InfrastructureTest {
                                        "aws-image",
                                        "admin",
                                        "keyname",
-                                       "privatekey",
+                                       PRIVATE_KEY,
                                        "2",
                                        "3",
                                        "wget -nv test.activeeon.com/rest/node.jar",
@@ -171,7 +173,7 @@ public class AWSEC2InfrastructureTest {
                                        "aws-image",
                                        "admin",
                                        "keyname",
-                                       "privatekey",
+                                       PRIVATE_KEY,
                                        "2",
                                        "3",
                                        "wget -nv test.activeeon.com/rest/node.jar",
@@ -255,7 +257,7 @@ public class AWSEC2InfrastructureTest {
                                        "aws-image",
                                        "admin",
                                        "keyname",
-                                       "privatekey",
+                                       PRIVATE_KEY,
                                        "2",
                                        "3",
                                        "wget -nv test.activeeon.com/rest/node.jar",
@@ -301,7 +303,7 @@ public class AWSEC2InfrastructureTest {
                                        "aws-image",
                                        "admin",
                                        "keyname",
-                                       "privatekey",
+                                       PRIVATE_KEY,
                                        "2",
                                        "3",
                                        "wget -nv test.activeeon.com/rest/node.jar",


### PR DESCRIPTION
- retrieve raw bytes from form and convert to String using ISO-8859-1 encoding instead of UTF-8