### PR TITLE
Update Jacoco Version 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -80,7 +80,7 @@ configure(javaSubprojects) {
 
 
     jacoco {
-        toolVersion = '0.7.1.201405082137'
+        toolVersion = '0.8.2'
     }
 
     jacocoTestReport {


### PR DESCRIPTION
Updating Jacoco version may resolve the issue of the Jenkins job **nodesource-addons-sonar**

**Error**:
Property 'sonar.abap.file.suffixes' is not declared as multi-values/property set but was read using 'getStringArray' method. The SonarQube plugin declaring this property should be updated.
:sonarqube FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':sonarqube'.
> **You are not using the latest JaCoCo binary format version, please consider upgrading to latest JaCoCo version**.