### PR TITLE
Fix deleting instance operation for Google Compute Engine

### DIFF
--- a/infrastructures/infrastructure-gce/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/GCEInfrastructure.java
+++ b/infrastructures/infrastructure-gce/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/GCEInfrastructure.java
@@ -358,6 +358,18 @@ public class GCEInfrastructure extends AbstractAddonInfrastructure {
     }
 
     @Override
+    public void shutDown() {
+        super.shutDown();
+        String infrastructureId = getInfrastructureId();
+        logger.info("Deleting infrastructure : " + infrastructureId + " and its underlying instances");
+        // should not delete instances here, because
+        // 1) terminateInfrastructure delete all the instances deployed with the infrastructure credential.
+        // (i.e., if multiple infrastructures use the same credential, it will delete the instances of other infrastructures.)
+        // 2) RMCore has already called removeNode for all the nodes belong to the infrastructure
+        connectorIaasController.terminateInfrastructure(infrastructureId, false);
+    }
+
+    @Override
     protected String getInstanceIdProperty(Node node) throws RMException {
         try {
             return node.getProperty(INSTANCE_TAG_NODE_PROPERTY);

--- a/infrastructures/infrastructure-gce/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/GCEInfrastructure.java
+++ b/infrastructures/infrastructure-gce/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/GCEInfrastructure.java
@@ -160,63 +160,81 @@ public class GCEInfrastructure extends AbstractAddonInfrastructure {
         }
         int parameterIndex = 0;
         // gceCredential
-        if (parameters[parameterIndex++] == null) {
+        if (parameters[parameterIndex] == null) {
             throw new IllegalArgumentException("The Google Cloud Platform service account must be specified");
         }
         // numberOfInstances
-        if (parameters[parameterIndex++] == null) {
+        parameterIndex++;
+        if (parameters[parameterIndex] == null) {
             throw new IllegalArgumentException("The number of instances to create must be specified");
         }
         // numberOfNodesPerInstance
-        if (parameters[parameterIndex++] == null) {
+        parameterIndex++;
+        if (parameters[parameterIndex] == null) {
             throw new IllegalArgumentException("The number of nodes per instance to deploy must be specified");
         }
         // vmUsername
+        parameterIndex++;
         if (parameters[parameterIndex] == null) {
-            parameters[parameterIndex++] = "";
+            parameters[parameterIndex] = "";
         }
         // vmPublicKey
+        parameterIndex++;
         if (parameters[parameterIndex] == null) {
-            parameters[parameterIndex++] = "";
+            parameters[parameterIndex] = "";
         }
         // vmPrivateKey
+        parameterIndex++;
         if (parameters[parameterIndex] == null) {
-            parameters[parameterIndex++] = "";
+            parameters[parameterIndex] = "";
         }
         // rmHostname
-        if (parameters[parameterIndex++] == null) {
+        parameterIndex++;
+        if (parameters[parameterIndex] == null) {
             throw new IllegalArgumentException("The resource manager hostname must be specified");
         }
+        if (parameters[parameterIndex].toString().contains("/")) {
+            throw new IllegalArgumentException(String.format("Invalid hostname %s (hostname should not contains '/').",
+                                                             parameters[parameterIndex]));
+        }
         // connectorIaasURL
-        if (parameters[parameterIndex++] == null) {
+        parameterIndex++;
+        if (parameters[parameterIndex] == null) {
             throw new IllegalArgumentException("The connector-iaas URL must be specified");
         }
         // downloadCommand
-        if (parameters[parameterIndex++] == null) {
+        parameterIndex++;
+        if (parameters[parameterIndex] == null) {
             throw new IllegalArgumentException("The command for downloading the node jar must be specified");
         }
         // additionalProperties
+        parameterIndex++;
         if (parameters[parameterIndex] == null) {
-            parameters[parameterIndex++] = "";
+            parameters[parameterIndex] = "";
         }
         // image
+        parameterIndex++;
         if (parameters[parameterIndex] == null) {
-            parameters[parameterIndex++] = DEFAULT_IMAGE;
+            parameters[parameterIndex] = DEFAULT_IMAGE;
         }
         // region
+        parameterIndex++;
         if (parameters[parameterIndex] == null) {
-            parameters[parameterIndex++] = DEFAULT_REGION;
+            parameters[parameterIndex] = DEFAULT_REGION;
         }
         // ram
+        parameterIndex++;
         if (parameters[parameterIndex] == null) {
-            parameters[parameterIndex++] = String.valueOf(DEFAULT_RAM);
+            parameters[parameterIndex] = String.valueOf(DEFAULT_RAM);
         }
         // cores
+        parameterIndex++;
         if (parameters[parameterIndex] == null) {
-            parameters[parameterIndex++] = String.valueOf(DEFAULT_CORES);
+            parameters[parameterIndex] = String.valueOf(DEFAULT_CORES);
         }
         // nodeTimeout
-        if (parameters[parameterIndex++] == null) {
+        parameterIndex++;
+        if (parameters[parameterIndex] == null) {
             throw new IllegalArgumentException("The node timeout must be specified");
         }
     }

--- a/infrastructures/infrastructure-gce/src/test/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/GCEInfrastructureTest.java
+++ b/infrastructures/infrastructure-gce/src/test/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/GCEInfrastructureTest.java
@@ -44,7 +44,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.mockito.Spy;
-import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.objectweb.proactive.core.ProActiveException;
 import org.objectweb.proactive.core.node.Node;
@@ -334,11 +333,8 @@ public class GCEInfrastructureTest {
             ((Runnable) invocation.getArguments()[0]).run();
             return null;
         }).when(nodeSource).executeInParallel(any(Runnable.class));
-
         final String instanceTag = "instance-tag";
-
         final String nodeName = "node-name";
-
         when(node.getProperty(GCEInfrastructure.INSTANCE_TAG_NODE_PROPERTY)).thenReturn(instanceTag);
         when(node.getProActiveRuntime()).thenReturn(proActiveRuntime);
         when(node.getNodeInformation()).thenReturn(nodeInformation);
@@ -379,6 +375,10 @@ public class GCEInfrastructureTest {
         doReturn(node).when(gceInfrastructure).getDeployingOrLostNode(anyString());
         gceInfrastructure.getNodesPerInstancesMap().put(instanceTag, Sets.newHashSet());
         doReturn(Arrays.asList(node)).when(gceInfrastructure).getDeployingAndLostNodes();
+        doAnswer((Answer<Object>) invocation -> {
+            ((Runnable) invocation.getArguments()[0]).run();
+            return null;
+        }).when(nodeSource).executeInParallel(any(Runnable.class));
         when(nodeSource.getName()).thenReturn(INFRASTRUCTURE_ID);
 
         gceInfrastructure.notifyDeployingNodeLost(nodeUrl);
@@ -410,6 +410,10 @@ public class GCEInfrastructureTest {
         gceInfrastructure.connectorIaasController = connectorIaasController;
         RMDeployingNode node = new RMDeployingNode(nodeName, new NodeSource(), "", new Client());
         doReturn(node).when(gceInfrastructure).getDeployingOrLostNode(anyString());
+        doAnswer((Answer<Object>) invocation -> {
+            ((Runnable) invocation.getArguments()[0]).run();
+            return null;
+        }).when(nodeSource).executeInParallel(any(Runnable.class));
         gceInfrastructure.getNodesPerInstancesMap()
                          .put(instanceTag, new HashSet<>(Arrays.asList("pamr://4097/node_0", "pamr://4097/node_1")));
 
@@ -424,7 +428,6 @@ public class GCEInfrastructureTest {
         final String nodeName1 = instanceTag + "_0";
         final String nodeName2 = instanceTag + "_1";
         final String nodeUrl1 = String.format("deploying://%s/%s", INFRASTRUCTURE_ID, nodeName1);
-        final String nodeUrl2 = String.format("deploying://%s/%s", INFRASTRUCTURE_ID, nodeName2);
         gceInfrastructure.configure(CREDENTIAL_FILE,
                                     NUMBER_INSTANCES,
                                     NUMBER_NODES_PER_INSTANCE,
@@ -447,6 +450,10 @@ public class GCEInfrastructureTest {
         gceInfrastructure.getNodesPerInstancesMap().put(instanceTag, Sets.newHashSet());
         RMDeployingNode node2 = new RMDeployingNode(nodeName2, new NodeSource(), "", new Client());
         doReturn(Arrays.asList(node1, node2)).when(gceInfrastructure).getDeployingAndLostNodes();
+        doAnswer((Answer<Object>) invocation -> {
+            ((Runnable) invocation.getArguments()[0]).run();
+            return null;
+        }).when(nodeSource).executeInParallel(any(Runnable.class));
         when(nodeSource.getName()).thenReturn(INFRASTRUCTURE_ID);
 
         gceInfrastructure.notifyDeployingNodeLost(nodeUrl1);
@@ -460,7 +467,6 @@ public class GCEInfrastructureTest {
         final String nodeName1 = instanceTag + "_0";
         final String nodeName2 = instanceTag + "_1";
         final String nodeUrl1 = String.format("deploying://%s/%s", INFRASTRUCTURE_ID, nodeName1);
-        final String nodeUrl2 = String.format("deploying://%s/%s", INFRASTRUCTURE_ID, nodeName2);
         gceInfrastructure.configure(CREDENTIAL_FILE,
                                     NUMBER_INSTANCES,
                                     NUMBER_NODES_PER_INSTANCE,
@@ -484,6 +490,10 @@ public class GCEInfrastructureTest {
         RMDeployingNode node2 = new RMDeployingNode(nodeName2, new NodeSource(), "", new Client());
         node2.setLost();
         doReturn(Arrays.asList(node1, node2)).when(gceInfrastructure).getDeployingAndLostNodes();
+        doAnswer((Answer<Object>) invocation -> {
+            ((Runnable) invocation.getArguments()[0]).run();
+            return null;
+        }).when(nodeSource).executeInParallel(any(Runnable.class));
         when(nodeSource.getName()).thenReturn(INFRASTRUCTURE_ID);
 
         gceInfrastructure.notifyDeployingNodeLost(nodeUrl1);

--- a/infrastructures/infrastructure-gce/src/test/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/GCEInfrastructureTest.java
+++ b/infrastructures/infrastructure-gce/src/test/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/GCEInfrastructureTest.java
@@ -44,6 +44,8 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.mockito.Spy;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
 import org.objectweb.proactive.core.ProActiveException;
 import org.objectweb.proactive.core.node.Node;
 import org.objectweb.proactive.core.node.NodeInformation;
@@ -310,7 +312,7 @@ public class GCEInfrastructureTest {
     }
 
     @Test
-    public void testRemoveNode() throws RMException, ProActiveException {
+    public void testRemoveNode() throws ProActiveException {
         gceInfrastructure.configure(CREDENTIAL_FILE,
                                     NUMBER_INSTANCES,
                                     NUMBER_NODES_PER_INSTANCE,
@@ -328,8 +330,15 @@ public class GCEInfrastructureTest {
                                     NODE_TIMEOUT);
         // re-assign needed because gceInfrastructure.configure new the object gceInfrastructure.connectorIaasController
         gceInfrastructure.connectorIaasController = connectorIaasController;
+        doAnswer((Answer<Object>) invocation -> {
+            ((Runnable) invocation.getArguments()[0]).run();
+            return null;
+        }).when(nodeSource).executeInParallel(any(Runnable.class));
+
         final String instanceTag = "instance-tag";
+
         final String nodeName = "node-name";
+
         when(node.getProperty(GCEInfrastructure.INSTANCE_TAG_NODE_PROPERTY)).thenReturn(instanceTag);
         when(node.getProActiveRuntime()).thenReturn(proActiveRuntime);
         when(node.getNodeInformation()).thenReturn(nodeInformation);


### PR DESCRIPTION
- [fix] To fix jClouds can't parse google-compute-engine instances with `DELETING` status, sync between the delete-instance thread and the create-instance thread.
- [improve] To improve user experience with the slow delete-instance operation (3 - 10 min), call it asynchronously.
- [minor] Check the parameter `hostname` not containing "/", and fix `parameterIndex` is not correctly incremented in some cases in the function `validate`.
- [fix] To fix delete a nodesource X will cause instances of other nodesources (Y, Z) which use the same cloud platform credentials, not delete instances when calling `terminateInfrastructure`, because: 
    1) currently `terminateInfrastructure` delete all the instances deployed with the infrastructure **credential**. 
    2) RMCore has already called removeNode for all the nodes belonging to the infrastructure