### PR TITLE
Custom nodejar url support

### DIFF
--- a/infrastructures/infrastructure-common/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/util/LinuxInitScriptGenerator.java
+++ b/infrastructures/infrastructure-common/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/util/LinuxInitScriptGenerator.java
@@ -108,6 +108,42 @@ public class LinuxInitScriptGenerator {
         return "nohup " + javaCommand + javaProperties + "  &";
     }
 
+    public String generateDefaultIaasConnectorURL(String DefaultRMHostname) {
+        if (nsConfig == null) {
+            try {
+                // If the configuration manager is not loaded, I load it with the NodeSource properties file
+                nsConfig = NSProperties.loadConfig();
+            } catch (ConfigurationException e) {
+                // If something go wring, I switch to hardcoded configuration, and leave.
+                logger.error("Exception when loading NodeSource properties", e);
+                return "http://" + DefaultRMHostname + ":8080/connector-iaas";
+            }
+        }
+        // I return the requested value while taking into account the configuration parameters
+        return nsConfig.getString(NSProperties.DEFAULT_PREFIX_CONNECTOR_IAAS_URL) + DefaultRMHostname +
+               nsConfig.getString(NSProperties.DEFAULT_SUFFIX_CONNECTOR_IAAS_URL);
+    }
+
+    public String generateDefaultDownloadCommand(String rmHostname) {
+        String suffixRmToNodeJarUrl;
+        if (nsConfig == null) {
+            // If the configuration manager is not loaded, I load it with the NodeSource properties file
+            try {
+                nsConfig = NSProperties.loadConfig();
+                suffixRmToNodeJarUrl = nsConfig.getString(NSProperties.DEFAULT_SUFFIX_RM_TO_NODEJAR_URL);
+            } catch (ConfigurationException e) {
+                // If something go wring, I switch to hardcoded configuration.
+                logger.error("Exception when loading NodeSource properties", e);
+                suffixRmToNodeJarUrl = ":8080/rest/node.jar";
+            }
+        } else {
+            // If the configuration manager is already loaded, I use it to retrieve the value of DEFAULT_SUFFIX_RM_TO_NODEJAR_URL
+            suffixRmToNodeJarUrl = nsConfig.getString(NSProperties.DEFAULT_SUFFIX_RM_TO_NODEJAR_URL);
+        }
+        // I return the generated node.jar download command.
+        return generateNodeDownloadCommand(rmHostname + suffixRmToNodeJarUrl);
+    }
+
     private static void loadNSConfig() {
         try {
             if (null == nsConfig) {

--- a/infrastructures/infrastructure-common/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/util/LinuxInitScriptGenerator.java
+++ b/infrastructures/infrastructure-common/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/util/LinuxInitScriptGenerator.java
@@ -131,9 +131,9 @@ public class LinuxInitScriptGenerator {
             }
             suffixRmToNodeJarUrl = nsConfig.getString(NSProperties.DEFAULT_SUFFIX_RM_TO_NODEJAR_URL);
         } catch (ConfigurationException e) {
-                // If something go wring, I switch to hardcoded configuration.
-                logger.error("Exception when loading NodeSource properties", e);
-                suffixRmToNodeJarUrl = ":8080/rest/node.jar";
+            // If something go wring, I switch to hardcoded configuration.
+            logger.error("Exception when loading NodeSource properties", e);
+            suffixRmToNodeJarUrl = ":8080/rest/node.jar";
         } finally {
             // I return the generated node.jar download command.
             return generateNodeDownloadCommand(rmHostname + suffixRmToNodeJarUrl);

--- a/infrastructures/infrastructure-common/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/util/LinuxInitScriptGenerator.java
+++ b/infrastructures/infrastructure-common/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/util/LinuxInitScriptGenerator.java
@@ -114,7 +114,7 @@ public class LinuxInitScriptGenerator {
             } catch (ConfigurationException e) {
                 // If something go wring, I switch to hardcoded configuration, and leave.
                 logger.error("Exception when loading NodeSource properties", e);
-                return "http://" + DefaultRMHostname + ":8080/connector-iaas";
+                // return null
             }
         }
         // I return the requested value while taking into account the configuration parameters
@@ -123,21 +123,18 @@ public class LinuxInitScriptGenerator {
     }
 
     public String generateDefaultDownloadCommand(String rmHostname) {
-        String suffixRmToNodeJarUrl = "";
-        try {
-            if (nsConfig == null) {
-                // If the configuration manager is not loaded, I load it with the NodeSource properties file
+        if (nsConfig == null) {
+            // If the configuration manager is not loaded, I load it with the NodeSource properties file
+            try {
                 nsConfig = NSProperties.loadConfig();
+            } catch (ConfigurationException e) {
+                // If something go wring, I switch to hardcoded configuration.
+                logger.error("Exception when loading NodeSource properties", e);
+                // return null obviously
             }
-            suffixRmToNodeJarUrl = nsConfig.getString(NSProperties.DEFAULT_SUFFIX_RM_TO_NODEJAR_URL);
-        } catch (ConfigurationException e) {
-            // If something go wring, I switch to hardcoded configuration.
-            logger.error("Exception when loading NodeSource properties", e);
-            suffixRmToNodeJarUrl = ":8080/rest/node.jar";
-        } finally {
-            // I return the generated node.jar download command.
-            return generateNodeDownloadCommand(rmHostname + suffixRmToNodeJarUrl);
         }
+        return generateNodeDownloadCommand(rmHostname +
+                                           nsConfig.getString(NSProperties.DEFAULT_SUFFIX_RM_TO_NODEJAR_URL));
     }
 
     private static void loadNSConfig() {

--- a/infrastructures/infrastructure-common/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/util/LinuxInitScriptGenerator.java
+++ b/infrastructures/infrastructure-common/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/util/LinuxInitScriptGenerator.java
@@ -47,10 +47,11 @@ public class LinuxInitScriptGenerator {
     public List<String> buildScript(String instanceId, String rmUrlToUse, String rmHostname,
             String instanceTagNodeProperty, String additionalProperties, String nsName, String nodeName,
             int numberOfNodesPerInstance) {
+        loadNSConfig();
         return buildScript(instanceId,
                            rmUrlToUse,
                            rmHostname,
-                           rmHostname + DEFAULT_SUFFIX_RM_TO_NODEJAR_URL,
+                           rmHostname + nsConfig.getString(NSProperties.DEFAULT_SUFFIX_RM_TO_NODEJAR_URL),
                            instanceTagNodeProperty,
                            additionalProperties,
                            nsName,

--- a/infrastructures/infrastructure-common/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/util/LinuxInitScriptGenerator.java
+++ b/infrastructures/infrastructure-common/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/util/LinuxInitScriptGenerator.java
@@ -36,8 +36,6 @@ import org.apache.log4j.Logger;
 
 public class LinuxInitScriptGenerator {
 
-    public static final String DEFAULT_SUFFIX_RM_TO_NODEJAR_URL = ":8080/rest/node.jar";
-
     private static final Logger logger = Logger.getLogger(LinuxInitScriptGenerator.class);
 
     private List<String> commands = new ArrayList<>();
@@ -125,23 +123,21 @@ public class LinuxInitScriptGenerator {
     }
 
     public String generateDefaultDownloadCommand(String rmHostname) {
-        String suffixRmToNodeJarUrl;
-        if (nsConfig == null) {
-            // If the configuration manager is not loaded, I load it with the NodeSource properties file
-            try {
+        String suffixRmToNodeJarUrl = "";
+        try {
+            if (nsConfig == null) {
+                // If the configuration manager is not loaded, I load it with the NodeSource properties file
                 nsConfig = NSProperties.loadConfig();
-                suffixRmToNodeJarUrl = nsConfig.getString(NSProperties.DEFAULT_SUFFIX_RM_TO_NODEJAR_URL);
-            } catch (ConfigurationException e) {
+            }
+            suffixRmToNodeJarUrl = nsConfig.getString(NSProperties.DEFAULT_SUFFIX_RM_TO_NODEJAR_URL);
+        } catch (ConfigurationException e) {
                 // If something go wring, I switch to hardcoded configuration.
                 logger.error("Exception when loading NodeSource properties", e);
                 suffixRmToNodeJarUrl = ":8080/rest/node.jar";
-            }
-        } else {
-            // If the configuration manager is already loaded, I use it to retrieve the value of DEFAULT_SUFFIX_RM_TO_NODEJAR_URL
-            suffixRmToNodeJarUrl = nsConfig.getString(NSProperties.DEFAULT_SUFFIX_RM_TO_NODEJAR_URL);
+        } finally {
+            // I return the generated node.jar download command.
+            return generateNodeDownloadCommand(rmHostname + suffixRmToNodeJarUrl);
         }
-        // I return the generated node.jar download command.
-        return generateNodeDownloadCommand(rmHostname + suffixRmToNodeJarUrl);
     }
 
     private static void loadNSConfig() {

--- a/infrastructures/infrastructure-common/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/util/LinuxInitScriptGenerator.java
+++ b/infrastructures/infrastructure-common/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/util/LinuxInitScriptGenerator.java
@@ -36,6 +36,8 @@ import org.apache.log4j.Logger;
 
 public class LinuxInitScriptGenerator {
 
+    public static final String DEFAULT_SUFFIX_RM_TO_NODEJAR_URL = ":8080/rest/node.jar";
+
     private static final Logger logger = Logger.getLogger(LinuxInitScriptGenerator.class);
 
     private List<String> commands = new ArrayList<>();
@@ -43,6 +45,20 @@ public class LinuxInitScriptGenerator {
     private static Configuration nsConfig = null;
 
     public List<String> buildScript(String instanceId, String rmUrlToUse, String rmHostname,
+            String instanceTagNodeProperty, String additionalProperties, String nsName, String nodeName,
+            int numberOfNodesPerInstance) {
+        return buildScript(instanceId,
+                           rmUrlToUse,
+                           rmHostname,
+                           rmHostname + DEFAULT_SUFFIX_RM_TO_NODEJAR_URL,
+                           instanceTagNodeProperty,
+                           additionalProperties,
+                           nsName,
+                           nodeName,
+                           numberOfNodesPerInstance);
+    }
+
+    public List<String> buildScript(String instanceId, String rmUrlToUse, String rmHostname, String nodeJarUrl,
             String instanceTagNodeProperty, String additionalProperties, String nsName, String nodeName,
             int numberOfNodesPerInstance) {
 
@@ -53,7 +69,7 @@ public class LinuxInitScriptGenerator {
             commands.add(nsConfig.getString(NSProperties.JRE_INSTALL_COMMAND));
         }
 
-        commands.add(generateNodeDownloadCommand(rmHostname));
+        commands.add(generateNodeDownloadCommand(nodeJarUrl));
 
         commands.add(generateNodeStartCommand(instanceId,
                                               rmUrlToUse,
@@ -69,8 +85,8 @@ public class LinuxInitScriptGenerator {
         return commands;
     }
 
-    public String generateNodeDownloadCommand(String rmHostname) {
-        return "wget -nv " + rmHostname + ":8080/rest/node.jar";
+    public String generateNodeDownloadCommand(String nodeJarUrl) {
+        return "wget -nv " + nodeJarUrl;
     }
 
     private String generateNodeStartCommand(String instanceId, String rmUrlToUse, String rmHostname,

--- a/infrastructures/infrastructure-common/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/util/NSProperties.java
+++ b/infrastructures/infrastructure-common/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/util/NSProperties.java
@@ -55,6 +55,12 @@ public class NSProperties {
 
     public static final String JAVA_COMMAND = "ns.script.linux.java.command";
 
+    public static final String DEFAULT_SUFFIX_RM_TO_NODEJAR_URL = "ns.default.suffix.rm.to.nodejar.url";
+
+    public static final String DEFAULT_SUFFIX_CONNECTOR_IAAS_URL = "ns.default.suffix.connector.iaas.url";
+
+    public static final String DEFAULT_PREFIX_CONNECTOR_IAAS_URL = "ns.default.prefix.connector.iaas.url";
+
     /**
      * loads NodeSource configuration.
      *

--- a/infrastructures/infrastructure-common/src/main/resources/NodeSource.properties
+++ b/infrastructures/infrastructure-common/src/main/resources/NodeSource.properties
@@ -4,3 +4,6 @@
 ns.jre.install = true
 ns.script.linux.jre.install.command = mkdir -p /tmp/node && cd /tmp/node && if ! type -p jre/bin/java; then wget -nv -N https://s3.amazonaws.com/ci-materials/Latest_jre/jre-8u131-linux-x64.tar.gz; tar -xf jre-8u131-linux-x64.tar.gz; mv  jre1.8.0_131/ jre;  fi
 ns.script.linux.java.command = jre/bin/java
+ns.default.suffix.rm.to.nodejar.url = :8080/rest/node.jar
+ns.default.suffix.connector.iaas.url = :8080/connector-iaas
+ns.default.prefix.connector.iaas.url = http://

--- a/infrastructures/infrastructure-gce/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/GCEInfrastructure.java
+++ b/infrastructures/infrastructure-gce/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/GCEInfrastructure.java
@@ -108,10 +108,10 @@ public class GCEInfrastructure extends AbstractAddonInfrastructure {
     protected String rmHostname = generateDefaultRMHostname();
 
     @Configurable(description = "Connector-iaas URL")
-    protected String connectorIaasURL = generateDefaultIaasConnectorURL();
+    protected String connectorIaasURL = linuxInitScriptGenerator.generateDefaultIaasConnectorURL(generateDefaultRMHostname());
 
     @Configurable(description = "Command used to download the node jar")
-    protected String downloadCommand = generateDefaultDownloadCommand();
+    protected String downloadCommand = linuxInitScriptGenerator.generateDefaultDownloadCommand(rmHostname);
 
     @Configurable(description = "(optional) Additional Java command properties (e.g. \"-Dpropertyname=propertyvalue\")")
     protected String additionalProperties = "-Dproactive.useIPaddress=true";
@@ -130,8 +130,6 @@ public class GCEInfrastructure extends AbstractAddonInfrastructure {
 
     @Configurable(description = "Node timeout in ms. After this timeout expired, the node is considered to be lost")
     protected int nodeTimeout = 2 * 60 * 1000;// 2 min
-
-    private static Configuration nsConfig = null;
 
     @Override
     public void configure(Object... parameters) {
@@ -421,42 +419,6 @@ public class GCEInfrastructure extends AbstractAddonInfrastructure {
             logger.warn(e);
             return "localhost";
         }
-    }
-
-    private String generateDefaultIaasConnectorURL() {
-        if (nsConfig == null) {
-            try {
-                // If the configuration manager is not loaded, I load it with the NodeSource properties file
-                nsConfig = NSProperties.loadConfig();
-            } catch (ConfigurationException e) {
-                // If something go wring, I switch to hardcoded configuration, and leave.
-                logger.error("Exception when loading NodeSource properties", e);
-                return "http://" + generateDefaultRMHostname() + ":8080/connector-iaas";
-            }
-        }
-        // I return the requested value while taking into account the configuration parameters
-        return nsConfig.getString(NSProperties.DEFAULT_PREFIX_CONNECTOR_IAAS_URL) + generateDefaultRMHostname() +
-               nsConfig.getString(NSProperties.DEFAULT_SUFFIX_CONNECTOR_IAAS_URL);
-    }
-
-    private String generateDefaultDownloadCommand() {
-        String suffixRmToNodeJarUrl;
-        if (nsConfig == null) {
-            // If the configuration manager is not loaded, I load it with the NodeSource properties file
-            try {
-                nsConfig = NSProperties.loadConfig();
-                suffixRmToNodeJarUrl = nsConfig.getString(NSProperties.DEFAULT_SUFFIX_RM_TO_NODEJAR_URL);
-            } catch (ConfigurationException e) {
-                // If something go wring, I switch to hardcoded configuration.
-                logger.error("Exception when loading NodeSource properties", e);
-                suffixRmToNodeJarUrl = ":8080/rest/node.jar";
-            }
-        } else {
-            // If the configuration manager is already loaded, I use it to retrieve the value of DEFAULT_SUFFIX_RM_TO_NODEJAR_URL
-            suffixRmToNodeJarUrl = nsConfig.getString(NSProperties.DEFAULT_SUFFIX_RM_TO_NODEJAR_URL);
-        }
-        // I return the generated node.jar download command.
-        return linuxInitScriptGenerator.generateNodeDownloadCommand(rmHostname + suffixRmToNodeJarUrl);
     }
 
     @SuppressWarnings("unchecked")

--- a/infrastructures/infrastructure-gce/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/GCEInfrastructure.java
+++ b/infrastructures/infrastructure-gce/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/GCEInfrastructure.java
@@ -33,15 +33,12 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
-import org.apache.commons.configuration2.Configuration;
-import org.apache.commons.configuration2.ex.ConfigurationException;
 import org.apache.log4j.Logger;
 import org.objectweb.proactive.core.ProActiveException;
 import org.objectweb.proactive.core.node.Node;
 import org.ow2.proactive.resourcemanager.exception.RMException;
 import org.ow2.proactive.resourcemanager.nodesource.common.Configurable;
 import org.ow2.proactive.resourcemanager.nodesource.infrastructure.util.LinuxInitScriptGenerator;
-import org.ow2.proactive.resourcemanager.nodesource.infrastructure.util.NSProperties;
 import org.ow2.proactive.resourcemanager.rmnode.RMDeployingNode;
 import org.ow2.proactive.resourcemanager.utils.RMNodeStarter;
 

--- a/infrastructures/infrastructure-gce/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/GCEInfrastructure.java
+++ b/infrastructures/infrastructure-gce/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/GCEInfrastructure.java
@@ -108,7 +108,8 @@ public class GCEInfrastructure extends AbstractAddonInfrastructure {
     protected String connectorIaasURL = "http://" + generateDefaultRMHostname() + ":8080/connector-iaas";
 
     @Configurable(description = "Command used to download the node jar")
-    protected String downloadCommand = linuxInitScriptGenerator.generateNodeDownloadCommand(rmHostname);
+    protected String downloadCommand = linuxInitScriptGenerator.generateNodeDownloadCommand(rmHostname +
+                                                                                            LinuxInitScriptGenerator.DEFAULT_SUFFIX_RM_TO_NODEJAR_URL);
 
     @Configurable(description = "(optional) Additional Java command properties (e.g. \"-Dpropertyname=propertyvalue\")")
     protected String additionalProperties = "-Dproactive.useIPaddress=true";

--- a/infrastructures/infrastructure-openstack/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/OpenstackInfrastructure.java
+++ b/infrastructures/infrastructure-openstack/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/OpenstackInfrastructure.java
@@ -32,15 +32,12 @@ import java.util.concurrent.*;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
-import org.apache.commons.configuration2.Configuration;
-import org.apache.commons.configuration2.ex.ConfigurationException;
 import org.apache.log4j.Logger;
 import org.objectweb.proactive.core.ProActiveException;
 import org.objectweb.proactive.core.node.Node;
 import org.ow2.proactive.resourcemanager.exception.RMException;
 import org.ow2.proactive.resourcemanager.nodesource.common.Configurable;
 import org.ow2.proactive.resourcemanager.nodesource.infrastructure.util.LinuxInitScriptGenerator;
-import org.ow2.proactive.resourcemanager.nodesource.infrastructure.util.NSProperties;
 
 import com.google.common.collect.Maps;
 

--- a/infrastructures/infrastructure-openstack/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/OpenstackInfrastructure.java
+++ b/infrastructures/infrastructure-openstack/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/OpenstackInfrastructure.java
@@ -114,7 +114,8 @@ public class OpenstackInfrastructure extends AbstractAddonInfrastructure {
     protected String rmHostname = generateDefaultRMHostname();
 
     @Configurable(description = "Command used to download the node jar")
-    protected String downloadCommand = linuxInitScriptGenerator.generateNodeDownloadCommand(rmHostname);
+    protected String downloadCommand = linuxInitScriptGenerator.generateNodeDownloadCommand(rmHostname +
+                                                                                            LinuxInitScriptGenerator.DEFAULT_SUFFIX_RM_TO_NODEJAR_URL);
 
     @Configurable(description = "Additional Java command properties (e.g. \"-Dpropertyname=propertyvalue\")")
     protected String additionalProperties = "-Dproactive.useIPaddress=true";


### PR DESCRIPTION
- Adding a new interface to retrieve node.jar from a custom URL in Linux
- Repercussion on defaultDownloadCommand parameter GCEInfrastructure and OpenstackInfrastructure

The main motivation for this PR is to enable the generation of working Linux provisioning script when RM is not accessible from node (PAMR-friendly environment).