### PR TITLE
Fix delete instance request failed because of resteasy version upgrade

### DIFF
--- a/infrastructures/infrastructure-common/build.gradle
+++ b/infrastructures/infrastructure-common/build.gradle
@@ -10,7 +10,7 @@ dependencies {
 
     compile 'com.google.guava:guava:19.0'
 
-    compile 'org.apache.httpcomponents:httpclient:4.5.6'
+    compile 'org.apache.httpcomponents:httpclient:4.5.2'
     compile 'org.apache.commons:commons-configuration2:2.2'
     compile 'org.apache.commons:commons-text:1.6'
     compile 'commons-beanutils:commons-beanutils:1.9.3'

--- a/infrastructures/infrastructure-common/build.gradle
+++ b/infrastructures/infrastructure-common/build.gradle
@@ -10,13 +10,13 @@ dependencies {
 
     compile 'com.google.guava:guava:19.0'
 
-    compile 'org.apache.httpcomponents:httpclient:4.5.2'
+    compile 'org.apache.httpcomponents:httpclient:4.5.6'
     compile 'org.apache.commons:commons-configuration2:2.2'
     compile 'org.apache.commons:commons-text:1.6'
     compile 'commons-beanutils:commons-beanutils:1.9.3'
 
-    compile 'org.jboss.resteasy:resteasy-jackson-provider:3.0.17.Final'
-    compile 'org.jboss.resteasy:resteasy-multipart-provider:3.0.17.Final'
+    compile 'org.jboss.resteasy:resteasy-jackson-provider:3.0.26.Final'
+    compile 'org.jboss.resteasy:resteasy-multipart-provider:3.0.26.Final'
     compile 'org.json:json:20151123'
 
     compile "org.ow2.proactive:rm-server:${rmVersion}"

--- a/infrastructures/infrastructure-common/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/RestClient.java
+++ b/infrastructures/infrastructure-common/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/RestClient.java
@@ -33,7 +33,6 @@ import javax.ws.rs.core.Response;
 
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.client.StandardHttpRequestRetryHandler;
-import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
 import org.jboss.resteasy.client.jaxrs.ClientHttpEngine;
 import org.jboss.resteasy.client.jaxrs.ResteasyClient;
 import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;


### PR DESCRIPTION
- upgrade resteasy lib version to "3.0.26" to be consistent with other services of proactive 
- retry the failed request to fix the "NoHttpResponseException" during the request of deleting an instance