### PR TITLE
fix [google-connector]: remove node should not run in parallel

### DIFF
--- a/infrastructures/infrastructure-gce/src/test/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/GCEInfrastructureTest.java
+++ b/infrastructures/infrastructure-gce/src/test/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/GCEInfrastructureTest.java
@@ -523,7 +523,7 @@ public class GCEInfrastructureTest {
     }
 
     @Test
-    public void testRemoveNode() throws ProActiveException {
+    public void testRemoveNode() throws ProActiveException, RMException {
         gceInfrastructure.configure(CREDENTIAL_FILE,
                                     NUMBER_INSTANCES,
                                     NUMBER_NODES_PER_INSTANCE,


### PR DESCRIPTION
Fix the conflict when the user deploys a new node source using the name of a deleting node source.

Only delete GCE instance should be run in parallel, instead of the entire remove node, so that, the new node source is deployed after old node source deregistration finished.