### PR TITLE
fix azure infrastructure booting init script

### DIFF
--- a/infrastructures/infrastructure-azure/src/test/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/AzureInfrastructureTest.java
+++ b/infrastructures/infrastructure-azure/src/test/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/AzureInfrastructureTest.java
@@ -107,7 +107,8 @@ public class AzureInfrastructureTest {
         assertThat(azureInfrastructure.downloadCommand, is(nullValue()));
         assertThat(azureInfrastructure.privateNetworkCIDR, is(nullValue()));
         assertThat(azureInfrastructure.staticPublicIP, is(true));
-        assertThat(azureInfrastructure.additionalProperties, is("-Dproactive.useIPaddress=true"));
+        assertThat(azureInfrastructure.additionalProperties,
+                   is("-Dproactive.useIPaddress=true -Dproactive.net.public_address=$(wget -qO- ipinfo.io/ip) -Dproactive.pnp.port=64738"));
     }
 
     @Test

--- a/infrastructures/infrastructure-common/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/util/LinuxInitScriptGenerator.java
+++ b/infrastructures/infrastructure-common/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/util/LinuxInitScriptGenerator.java
@@ -105,7 +105,9 @@ public class LinuxInitScriptGenerator {
 
         String nodeNamingOption = (nodeBaseName == null || nodeBaseName.isEmpty()) ? "" : " -n " + nodeBaseName;
 
-        String javaProperties = " -Dproactive.communication.protocol=" + protocol +
+        String jythonPath = nsConfig.getString(NSProperties.DEFAULT_JYTHON_PATH);
+
+        String javaProperties = " -Dproactive.communication.protocol=" + protocol + " -Dpython.path=" + jythonPath +
                                 " -Dproactive.pamr.router.address=" + rmHostname + " -D" + instanceTagNodeProperty +
                                 "=" + instanceId + " " + additionalProperties + " -r " + rmUrlToUse + " -s " + nsName +
                                 nodeNamingOption + " -w " + numberOfNodesPerInstance;

--- a/infrastructures/infrastructure-common/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/util/NSProperties.java
+++ b/infrastructures/infrastructure-common/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/util/NSProperties.java
@@ -61,6 +61,8 @@ public class NSProperties {
 
     public static final String DEFAULT_PREFIX_CONNECTOR_IAAS_URL = "ns.default.prefix.connector.iaas.url";
 
+    public static final String DEFAULT_JYTHON_PATH = "ns.default.jython.path";
+
     /**
      * loads NodeSource configuration.
      *

--- a/infrastructures/infrastructure-common/src/main/resources/NodeSource.properties
+++ b/infrastructures/infrastructure-common/src/main/resources/NodeSource.properties
@@ -7,3 +7,4 @@ ns.script.linux.java.command = jre/bin/java
 ns.default.suffix.rm.to.nodejar.url = :8080/rest/node.jar
 ns.default.suffix.connector.iaas.url = :8080/connector-iaas
 ns.default.prefix.connector.iaas.url = http://
+ns.default.jython.path = /tmp/node/lib/jython-standalone-2.7.0.jar/Lib


### PR DESCRIPTION
This PR fixes #64 . Originally, a custom image with java pre-installed was required to launch an instance. We change the original azure boot script to the new one created with the `LinuxInitScriptGenerator`, which installs java on the fly.

- This change represents a regression in that we won't support windows VMs for the moment (but it is the same case for the rest of infrastructures).
- We piggyback the addition of `-Dpython.path` property to be able to run fork environments.
- The modifications are intended for this release, a refactoring of the class will be required later to make it consistent with the other infrastructures, and to enable asynchronous calls to Azure.