### PR TITLE
Fix AWS infrastructure (support dynamic policy & declare deploying nodes & more robust delete instances)

### DIFF
--- a/infrastructures/infrastructure-aws-ec2/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/AWSEC2Infrastructure.java
+++ b/infrastructures/infrastructure-aws-ec2/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/AWSEC2Infrastructure.java
@@ -25,8 +25,6 @@
  */
 package org.ow2.proactive.resourcemanager.nodesource.infrastructure;
 
-import static org.ow2.proactive.resourcemanager.core.properties.PAResourceManagerProperties.RM_CLOUD_INFRASTRUCTURES_DESTROY_INSTANCES_ON_SHUTDOWN;
-
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.nio.charset.StandardCharsets;
@@ -45,7 +43,6 @@ import org.ow2.proactive.resourcemanager.nodesource.common.Configurable;
 import org.ow2.proactive.resourcemanager.nodesource.infrastructure.util.LinuxInitScriptGenerator;
 import org.python.google.common.collect.Sets;
 
-import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 
 
@@ -54,6 +51,10 @@ public class AWSEC2Infrastructure extends AbstractAddonInfrastructure {
     public static final String INSTANCE_ID_NODE_PROPERTY = "instanceId";
 
     public static final String INFRASTRUCTURE_TYPE = "aws-ec2";
+
+    private static final int NUMBER_OF_PARAMETERS = 17;
+
+    private static final boolean DESTROY_INSTANCES_ON_SHUTDOWN = true;
 
     private static final Logger logger = Logger.getLogger(AWSEC2Infrastructure.class);
 
@@ -149,82 +150,94 @@ public class AWSEC2Infrastructure extends AbstractAddonInfrastructure {
     }
 
     private void validate(Object[] parameters) {
-        int parameterIndex = 0;
-        if (parameters == null || parameters.length < 14) {
+        if (parameters == null || parameters.length < NUMBER_OF_PARAMETERS) {
             throw new IllegalArgumentException("Invalid parameters for EC2Infrastructure creation");
         }
-
-        if (parameters[parameterIndex++] == null) {
+        int parameterIndex = 0;
+        // aws_key
+        if (parameters[parameterIndex] == null) {
             throw new IllegalArgumentException("EC2 key must be specified");
         }
-
-        if (parameters[parameterIndex++] == null) {
+        parameterIndex++;
+        // aws_secret_key
+        if (parameters[parameterIndex] == null) {
             throw new IllegalArgumentException("EC2 secret key  must be specified");
         }
-
-        if (parameters[parameterIndex++] == null) {
+        parameterIndex++;
+        // rmHostname
+        if (parameters[parameterIndex] == null) {
             throw new IllegalArgumentException("The Resource manager hostname must be specified");
         }
-
-        if (parameters[parameterIndex++] == null) {
+        parameterIndex++;
+        // connectorIaasURL
+        if (parameters[parameterIndex] == null) {
             throw new IllegalArgumentException("The connector-iaas URL must be specified");
         }
-
-        if (parameters[parameterIndex++] == null) {
+        parameterIndex++;
+        // image
+        if (parameters[parameterIndex] == null) {
             throw new IllegalArgumentException("The image id must be specified");
         }
-
-        // VM username
-        if (parameters[parameterIndex] == null) {
-            parameters[parameterIndex++] = "";
-        }
-
-        // key pair name
-        if (parameters[parameterIndex] == null) {
-            parameters[parameterIndex++] = "";
-        }
-
-        // private key file
-        if (parameters[parameterIndex] == null) {
-            parameters[parameterIndex++] = "";
-        }
-
-        if (parameters[parameterIndex++] == null) {
-            throw new IllegalArgumentException("The number of instances to create must be specified");
-        }
-
-        if (parameters[parameterIndex++] == null) {
-            throw new IllegalArgumentException("The number of nodes per instance to deploy must be specified");
-        }
-
-        if (parameters[parameterIndex++] == null) {
-            throw new IllegalArgumentException("The download node.jar command must be specified");
-        }
-
-        if (parameters[parameterIndex] == null) {
-            parameters[parameterIndex++] = "";
-        }
-
-        if (parameters[parameterIndex++] == null) {
-            throw new IllegalArgumentException("The amount of minimum RAM required must be specified");
-        }
-
-        if (parameters[parameterIndex++] == null) {
-            throw new IllegalArgumentException("The minimum number of cores required must be specified");
-        }
-
-        if (parameters[parameterIndex] == null) {
-            parameters[parameterIndex++] = "";
-        }
-
-        if (parameters[parameterIndex] == null) {
-            parameters[parameterIndex++] = "";
-        }
-
+        parameterIndex++;
+        // vmUsername
         if (parameters[parameterIndex] == null) {
             parameters[parameterIndex] = "";
         }
-
+        parameterIndex++;
+        // vmKeyPairName
+        if (parameters[parameterIndex] == null) {
+            parameters[parameterIndex] = "";
+        }
+        parameterIndex++;
+        // vmPrivateKey
+        if (parameters[parameterIndex] == null) {
+            parameters[parameterIndex] = "";
+        }
+        parameterIndex++;
+        // numberOfInstances
+        if (parameters[parameterIndex] == null) {
+            throw new IllegalArgumentException("The number of instances to create must be specified");
+        }
+        parameterIndex++;
+        // numberOfNodesPerInstance
+        if (parameters[parameterIndex] == null) {
+            throw new IllegalArgumentException("The number of nodes per instance to deploy must be specified");
+        }
+        parameterIndex++;
+        // downloadCommand
+        if (parameters[parameterIndex] == null) {
+            throw new IllegalArgumentException("The download node.jar command must be specified");
+        }
+        parameterIndex++;
+        // additionalProperties
+        if (parameters[parameterIndex] == null) {
+            parameters[parameterIndex] = "";
+        }
+        parameterIndex++;
+        // ram
+        if (parameters[parameterIndex] == null) {
+            throw new IllegalArgumentException("The amount of minimum RAM required must be specified");
+        }
+        parameterIndex++;
+        // cores
+        if (parameters[parameterIndex] == null) {
+            throw new IllegalArgumentException("The minimum number of cores required must be specified");
+        }
+        parameterIndex++;
+        // spotPrice
+        if (parameters[parameterIndex] == null) {
+            parameters[parameterIndex] = "";
+        }
+        parameterIndex++;
+        // securityGroupNames
+        if (parameters[parameterIndex] == null) {
+            parameters[parameterIndex] = "";
+        }
+        parameterIndex++;
+        // subnetId
+        if (parameters[parameterIndex] == null) {
+            parameters[parameterIndex] = "";
+        }
     }
 
     private void createAwsInfrastructure() {
@@ -232,7 +245,7 @@ public class AWSEC2Infrastructure extends AbstractAddonInfrastructure {
                                                      aws_key,
                                                      aws_secret_key,
                                                      null,
-                                                     RM_CLOUD_INFRASTRUCTURES_DESTROY_INSTANCES_ON_SHUTDOWN.getValueAsBoolean());
+                                                     DESTROY_INSTANCES_ON_SHUTDOWN);
     }
 
     @Override

--- a/infrastructures/infrastructure-aws-ec2/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/AWSEC2Infrastructure.java
+++ b/infrastructures/infrastructure-aws-ec2/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/AWSEC2Infrastructure.java
@@ -520,6 +520,15 @@ public class AWSEC2Infrastructure extends AbstractAddonInfrastructure {
         return "Handles nodes from the Amazon Elastic Compute Cloud Service.";
     }
 
+    @Override
+    public void shutDown() {
+        super.shutDown();
+        String infrastructureId = getInfrastructureId();
+        logger.info(String.format("Deleting infrastructure (%s) and its instances", infrastructureId));
+        connectorIaasController.terminateInfrastructure(infrastructureId, true);
+        logger.info(String.format("Successfully deleted infrastructure (%s) and its instances.", infrastructureId));
+    }
+
     /**
      * {@inheritDoc}
      */

--- a/infrastructures/infrastructure-aws-ec2/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/AWSEC2Infrastructure.java
+++ b/infrastructures/infrastructure-aws-ec2/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/AWSEC2Infrastructure.java
@@ -117,7 +117,7 @@ public class AWSEC2Infrastructure extends AbstractAddonInfrastructure {
     @Configurable(description = "(optional) The minimum number of CPU cores required for each VM")
     protected int cores = DEFAULT_CORES;
 
-    // disable to configure the parameter spotPrice for the moment, because we don't yet have a checking mechanism for it now, but it may cause the RM portal blocked (hanging in createInstance).
+    // TODO disable to configure the parameter spotPrice for the moment, because we don't yet have a checking mechanism for it now, but it may cause the RM portal blocked (hanging in createInstance).
     //    @Configurable(description = "(optional) The maximum price that you are willing to pay per hour per instance (your bid price)")
     protected String spotPrice = "";
 
@@ -164,6 +164,7 @@ public class AWSEC2Infrastructure extends AbstractAddonInfrastructure {
         this.vmPrivateKey = (byte[]) parameters[parameterIndex++];
         this.ram = parseIntParameter("ram", parameters[parameterIndex++]);
         this.cores = parseIntParameter("cores", parameters[parameterIndex++]);
+        //        TODO disable to configure the parameter spotPrice for the moment
         //        this.spotPrice = parameters[parameterIndex++].toString().trim();
         this.securityGroupIds = parameters[parameterIndex++].toString().trim();
         this.subnetId = parameters[parameterIndex++].toString().trim();
@@ -235,6 +236,7 @@ public class AWSEC2Infrastructure extends AbstractAddonInfrastructure {
             parameters[parameterIndex] = DEFAULT_CORES;
         }
         parameterIndex++;
+        //        TODO disable to configure the parameter spotPrice for the moment
         //        // spotPrice
         //        if (parameters[parameterIndex] == null) {
         //            parameters[parameterIndex] = "";

--- a/infrastructures/infrastructure-aws-ec2/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/AWSEC2Infrastructure.java
+++ b/infrastructures/infrastructure-aws-ec2/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/AWSEC2Infrastructure.java
@@ -54,7 +54,7 @@ public class AWSEC2Infrastructure extends AbstractAddonInfrastructure {
 
     public static final String INFRASTRUCTURE_TYPE = "aws-ec2";
 
-    private static final int NUMBER_OF_PARAMETERS = 18;
+    private static final int NUMBER_OF_PARAMETERS = 17;
 
     private static final String DEFAULT_IMAGE = "eu-west-3/ami-03bca18cb3dc173c9";
 
@@ -86,10 +86,10 @@ public class AWSEC2Infrastructure extends AbstractAddonInfrastructure {
 
     private boolean isCreatedInfrastructure = false;
 
-    @Configurable(description = "Your AWS access key ID (for example, AKIAIOSFODNN7EXAMPLE)")
+    @Configurable(description = "Your AWS access key ID (e.g., AKIAIOSFODNN7EXAMPLE)")
     protected String awsKey = null;
 
-    @Configurable(password = true, description = "Your AWS secret access key (for example, wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY)")
+    @Configurable(description = "Your AWS secret access key (e.g., wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY)")
     protected String awsSecretKey = null;
 
     @Configurable(description = "The number of VMs to create (maximum number of VMs in case of dynamic policy)")
@@ -117,13 +117,14 @@ public class AWSEC2Infrastructure extends AbstractAddonInfrastructure {
     @Configurable(description = "(optional) The minimum number of CPU cores required for each VM")
     protected int cores = DEFAULT_CORES;
 
-    @Configurable(description = "(optional) The maximum price that you are willing to pay per hour per instance (your bid price)")
-    protected String spotPrice = null;
+    // disable to configure the parameter spotPrice for the moment, because we don't yet have a checking mechanism for it now, but it may cause the RM portal blocked (hanging in createInstance).
+    //    @Configurable(description = "(optional) The maximum price that you are willing to pay per hour per instance (your bid price)")
+    protected String spotPrice = "";
 
-    @Configurable(description = "(optional) The name(s) of the Security group(s) for VMs")
-    protected String securityGroupNames = null;
+    @Configurable(description = "(optional) The ids(s) of the security group(s) for VMs, spearated by comma in case of multiple ids.")
+    protected String securityGroupIds = null;
 
-    @Configurable(description = "(optional) The Subnet ID which is added to a specific Amazon VPC.")
+    @Configurable(description = "(optional) The subnet ID which is added to a specific Amazon VPC.")
     protected String subnetId = null;
 
     @Configurable(description = "Resource Manager hostname or ip address (must be accessible from nodes)")
@@ -163,8 +164,8 @@ public class AWSEC2Infrastructure extends AbstractAddonInfrastructure {
         this.vmPrivateKey = (byte[]) parameters[parameterIndex++];
         this.ram = parseIntParameter("ram", parameters[parameterIndex++]);
         this.cores = parseIntParameter("cores", parameters[parameterIndex++]);
-        this.spotPrice = parameters[parameterIndex++].toString().trim();
-        this.securityGroupNames = parameters[parameterIndex++].toString().trim();
+        //        this.spotPrice = parameters[parameterIndex++].toString().trim();
+        this.securityGroupIds = parameters[parameterIndex++].toString().trim();
         this.subnetId = parameters[parameterIndex++].toString().trim();
         this.rmHostname = parameters[parameterIndex++].toString().trim();
         this.connectorIaasURL = parameters[parameterIndex++].toString().trim();
@@ -234,12 +235,12 @@ public class AWSEC2Infrastructure extends AbstractAddonInfrastructure {
             parameters[parameterIndex] = DEFAULT_CORES;
         }
         parameterIndex++;
-        // spotPrice
-        if (parameters[parameterIndex] == null) {
-            parameters[parameterIndex] = "";
-        }
-        parameterIndex++;
-        // securityGroupNames
+        //        // spotPrice
+        //        if (parameters[parameterIndex] == null) {
+        //            parameters[parameterIndex] = "";
+        //        }
+        //        parameterIndex++;
+        // securityGroupIds
         if (parameters[parameterIndex] == null) {
             parameters[parameterIndex] = "";
         }
@@ -368,7 +369,7 @@ public class AWSEC2Infrastructure extends AbstractAddonInfrastructure {
 
     private Set<String> createInstances(String infrastructureId, String keyPairName, int nbInstances) {
         // create instances
-        if (spotPrice.isEmpty() && securityGroupNames.isEmpty() && subnetId.isEmpty()) {
+        if (spotPrice.isEmpty() && securityGroupIds.isEmpty() && subnetId.isEmpty()) {
             return connectorIaasController.createAwsEc2Instances(infrastructureId,
                                                                  infrastructureId,
                                                                  image,
@@ -385,7 +386,7 @@ public class AWSEC2Infrastructure extends AbstractAddonInfrastructure {
                                                                             cores,
                                                                             ram,
                                                                             spotPrice,
-                                                                            securityGroupNames,
+                                                                            securityGroupIds,
                                                                             subnetId,
                                                                             null,
                                                                             vmUsername,

--- a/infrastructures/infrastructure-aws-ec2/src/test/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/AWSEC2InfrastructureTest.java
+++ b/infrastructures/infrastructure-aws-ec2/src/test/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/AWSEC2InfrastructureTest.java
@@ -32,16 +32,18 @@ import static org.junit.Assert.assertThat;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyList;
 import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 import java.util.AbstractMap;
+import java.util.ArrayList;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.mockito.Spy;
+import org.mockito.stubbing.Answer;
 import org.objectweb.proactive.core.ProActiveException;
 import org.objectweb.proactive.core.node.Node;
 import org.objectweb.proactive.core.node.NodeInformation;
@@ -56,8 +58,12 @@ public class AWSEC2InfrastructureTest {
 
     private static final byte[] PRIVATE_KEY = new byte[] { 0, 1, 2, 3, 4 };
 
+    private static final int NODE_TIMEOUT = 120000;
+
     private static final boolean DESTROY_INSTANCES_ON_SHUTDOWN = true;
 
+    @InjectMocks
+    @Spy
     private AWSEC2Infrastructure awsec2Infrastructure;
 
     @Mock
@@ -81,7 +87,6 @@ public class AWSEC2InfrastructureTest {
     @Before
     public void init() {
         MockitoAnnotations.initMocks(this);
-        awsec2Infrastructure = new AWSEC2Infrastructure();
         awsec2Infrastructure.setRmDbManager(dbManager);
         awsec2Infrastructure.initializePersistedInfraVariables();
         when(connectorIaasController.createAwsEc2KeyPair(anyString(),
@@ -139,7 +144,8 @@ public class AWSEC2InfrastructureTest {
                                        1,
                                        "0.05",
                                        "default",
-                                       "127.0.0.1");
+                                       "127.0.0.1",
+                                       NODE_TIMEOUT);
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -184,11 +190,20 @@ public class AWSEC2InfrastructureTest {
                                        1,
                                        "0.05",
                                        "default",
-                                       "127.0.0.1");
+                                       "127.0.0.1",
+                                       NODE_TIMEOUT);
 
         awsec2Infrastructure.connectorIaasController = connectorIaasController;
         awsec2Infrastructure.nodeSource = nodeSource;
         awsec2Infrastructure.setRmUrl("http://test.activeeon.com");
+        doAnswer((Answer<Object>) invocation -> {
+            ((Runnable) invocation.getArguments()[0]).run();
+            return null;
+        }).when(nodeSource).executeInParallel(any(Runnable.class));
+        doReturn(new ArrayList<>()).when(awsec2Infrastructure).addMultipleDeployingNodes(anyListOf(String.class),
+                                                                                         anyString(),
+                                                                                         anyString(),
+                                                                                         anyLong());
 
         when(connectorIaasController.createInfrastructure("node_source_name",
                                                           "aws_key",
@@ -211,8 +226,6 @@ public class AWSEC2InfrastructureTest {
                                                                                                              "456"));
 
         awsec2Infrastructure.acquireNode();
-
-        Thread.sleep(500);
 
         verify(connectorIaasController, times(1)).waitForConnectorIaasToBeUP();
 
@@ -264,11 +277,20 @@ public class AWSEC2InfrastructureTest {
                                        1,
                                        "0.05",
                                        "default",
-                                       "127.0.0.1");
+                                       "127.0.0.1",
+                                       NODE_TIMEOUT);
 
         awsec2Infrastructure.connectorIaasController = connectorIaasController;
         awsec2Infrastructure.nodeSource = nodeSource;
         awsec2Infrastructure.setRmUrl("http://test.activeeon.com");
+        doAnswer((Answer<Object>) invocation -> {
+            ((Runnable) invocation.getArguments()[0]).run();
+            return null;
+        }).when(nodeSource).executeInParallel(any(Runnable.class));
+        doReturn(new ArrayList<>()).when(awsec2Infrastructure).addMultipleDeployingNodes(anyListOf(String.class),
+                                                                                         anyString(),
+                                                                                         anyString(),
+                                                                                         anyLong());
 
         when(connectorIaasController.createInfrastructure("node_source_name",
                                                           "aws_key",
@@ -291,8 +313,6 @@ public class AWSEC2InfrastructureTest {
                                                                                                              "456"));
 
         awsec2Infrastructure.acquireAllNodes();
-
-        Thread.sleep(500);
 
         verify(connectorIaasController, times(1)).waitForConnectorIaasToBeUP();
 
@@ -344,7 +364,8 @@ public class AWSEC2InfrastructureTest {
                                        1,
                                        "0.05",
                                        "default",
-                                       "127.0.0.1");
+                                       "127.0.0.1",
+                                       NODE_TIMEOUT);
 
         awsec2Infrastructure.connectorIaasController = connectorIaasController;
 
@@ -390,7 +411,8 @@ public class AWSEC2InfrastructureTest {
                                        1,
                                        "0.05",
                                        "default",
-                                       "127.0.0.1");
+                                       "127.0.0.1",
+                                       NODE_TIMEOUT);
 
         awsec2Infrastructure.connectorIaasController = connectorIaasController;
 

--- a/infrastructures/infrastructure-aws-ec2/src/test/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/AWSEC2InfrastructureTest.java
+++ b/infrastructures/infrastructure-aws-ec2/src/test/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/AWSEC2InfrastructureTest.java
@@ -214,7 +214,7 @@ public class AWSEC2InfrastructureTest {
         when(connectorIaasController.createAwsEc2InstancesWithOptions("node_source_name",
                                                                       "node_source_name",
                                                                       "aws-image",
-                                                                      2,
+                                                                      1,
                                                                       1,
                                                                       512,
                                                                       "0.05",
@@ -222,8 +222,7 @@ public class AWSEC2InfrastructureTest {
                                                                       "127.0.0.1",
                                                                       null,
                                                                       "admin",
-                                                                      "keyname")).thenReturn(Sets.newHashSet("123",
-                                                                                                             "456"));
+                                                                      "keyname")).thenReturn(Sets.newHashSet("123"));
 
         awsec2Infrastructure.acquireNode();
 
@@ -238,7 +237,7 @@ public class AWSEC2InfrastructureTest {
         verify(connectorIaasController).createAwsEc2InstancesWithOptions("node_source_name",
                                                                          "node_source_name",
                                                                          "aws-image",
-                                                                         2,
+                                                                         1,
                                                                          1,
                                                                          512,
                                                                          "0.05",
@@ -248,7 +247,7 @@ public class AWSEC2InfrastructureTest {
                                                                          "admin",
                                                                          "keyname");
 
-        verify(connectorIaasController, times(2)).executeScriptWithKeyAuthentication(anyString(),
+        verify(connectorIaasController, times(1)).executeScriptWithKeyAuthentication(anyString(),
                                                                                      anyString(),
                                                                                      anyList(),
                                                                                      anyString(),

--- a/infrastructures/infrastructure-aws-ec2/src/test/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/AWSEC2InfrastructureTest.java
+++ b/infrastructures/infrastructure-aws-ec2/src/test/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/AWSEC2InfrastructureTest.java
@@ -76,7 +76,7 @@ public class AWSEC2InfrastructureTest {
 
     private static final int CORES = 1;
 
-    private static final String SPOT_PRICE = "0.05";
+    private static final String SPOT_PRICE = ""; //"0.05";
 
     private static final String SECURITY_GROUP_NAMES = "sg-default";
 
@@ -157,7 +157,7 @@ public class AWSEC2InfrastructureTest {
                                        VM_PRIVATE_KEY,
                                        RAM,
                                        CORES,
-                                       SPOT_PRICE,
+                                       //                                       SPOT_PRICE,
                                        SECURITY_GROUP_NAMES,
                                        SUBNET_ID,
                                        RM_HOSTNAME,
@@ -177,7 +177,7 @@ public class AWSEC2InfrastructureTest {
                                        VM_PRIVATE_KEY,
                                        RAM,
                                        CORES,
-                                       SPOT_PRICE,
+                                       //                                       SPOT_PRICE,
                                        SECURITY_GROUP_NAMES,
                                        SUBNET_ID,
                                        RM_HOSTNAME,
@@ -199,7 +199,7 @@ public class AWSEC2InfrastructureTest {
                                        VM_PRIVATE_KEY,
                                        RAM,
                                        CORES,
-                                       SPOT_PRICE,
+                                       //                                       SPOT_PRICE,
                                        SECURITY_GROUP_NAMES,
                                        SUBNET_ID,
                                        RM_HOSTNAME,
@@ -294,7 +294,7 @@ public class AWSEC2InfrastructureTest {
                                        VM_PRIVATE_KEY,
                                        RAM,
                                        CORES,
-                                       SPOT_PRICE,
+                                       //                                       SPOT_PRICE,
                                        SECURITY_GROUP_NAMES,
                                        SUBNET_ID,
                                        RM_HOSTNAME,
@@ -389,7 +389,7 @@ public class AWSEC2InfrastructureTest {
                                        VM_PRIVATE_KEY,
                                        RAM,
                                        CORES,
-                                       SPOT_PRICE,
+                                       //                                       SPOT_PRICE,
                                        SECURITY_GROUP_NAMES,
                                        SUBNET_ID,
                                        RM_HOSTNAME,
@@ -435,7 +435,7 @@ public class AWSEC2InfrastructureTest {
                                        VM_PRIVATE_KEY,
                                        RAM,
                                        CORES,
-                                       SPOT_PRICE,
+                                       //                                       SPOT_PRICE,
                                        SECURITY_GROUP_NAMES,
                                        SUBNET_ID,
                                        RM_HOSTNAME,

--- a/infrastructures/infrastructure-aws-ec2/src/test/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/AWSEC2InfrastructureTest.java
+++ b/infrastructures/infrastructure-aws-ec2/src/test/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/AWSEC2InfrastructureTest.java
@@ -56,6 +56,8 @@ public class AWSEC2InfrastructureTest {
 
     private static final byte[] PRIVATE_KEY = new byte[] { 0, 1, 2, 3, 4 };
 
+    private static final boolean DESTROY_INSTANCES_ON_SHUTDOWN = true;
+
     private AWSEC2Infrastructure awsec2Infrastructure;
 
     @Mock
@@ -192,7 +194,7 @@ public class AWSEC2InfrastructureTest {
                                                           "aws_key",
                                                           "aws_secret_key",
                                                           null,
-                                                          true)).thenReturn("node_source_name");
+                                                          DESTROY_INSTANCES_ON_SHUTDOWN)).thenReturn("node_source_name");
 
         when(connectorIaasController.createAwsEc2InstancesWithOptions("node_source_name",
                                                                       "node_source_name",
@@ -218,7 +220,7 @@ public class AWSEC2InfrastructureTest {
                                                              "aws_key",
                                                              "aws_secret_key",
                                                              null,
-                                                             false);
+                                                             DESTROY_INSTANCES_ON_SHUTDOWN);
 
         verify(connectorIaasController).createAwsEc2InstancesWithOptions("node_source_name",
                                                                          "node_source_name",
@@ -272,7 +274,7 @@ public class AWSEC2InfrastructureTest {
                                                           "aws_key",
                                                           "aws_secret_key",
                                                           null,
-                                                          true)).thenReturn("node_source_name");
+                                                          DESTROY_INSTANCES_ON_SHUTDOWN)).thenReturn("node_source_name");
 
         when(connectorIaasController.createAwsEc2InstancesWithOptions("node_source_name",
                                                                       "node_source_name",
@@ -298,7 +300,7 @@ public class AWSEC2InfrastructureTest {
                                                              "aws_key",
                                                              "aws_secret_key",
                                                              null,
-                                                             false);
+                                                             DESTROY_INSTANCES_ON_SHUTDOWN);
 
         verify(connectorIaasController).createAwsEc2InstancesWithOptions("node_source_name",
                                                                          "node_source_name",

--- a/infrastructures/infrastructure-common/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/AbstractAddonInfrastructure.java
+++ b/infrastructures/infrastructure-common/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/AbstractAddonInfrastructure.java
@@ -455,6 +455,11 @@ public abstract class AbstractAddonInfrastructure extends InfrastructureManager 
         return getNodesPerInstancesMapCopy().size();
     }
 
+    protected boolean existRegisteredNodesOnInstance(String instanceTag) {
+        nodesPerInstance = getNodesPerInstancesMap();
+        return nodesPerInstance.get(instanceTag) != null && !nodesPerInstance.get(instanceTag).isEmpty();
+    }
+
     /**
      * Take into account a node in the tracked removed nodes and mark the
      * given instance as free if all the nodes are marked as removed for this

--- a/infrastructures/infrastructure-common/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/AbstractAddonInfrastructure.java
+++ b/infrastructures/infrastructure-common/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/AbstractAddonInfrastructure.java
@@ -580,4 +580,23 @@ public abstract class AbstractAddonInfrastructure extends InfrastructureManager 
                     instancesWithoutNodesMap);
     }
 
+    protected int parseIntParameter(String parameterName, Object parameter) {
+        try {
+            return Integer.parseInt(parameter.toString().trim());
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException(String.format("Non numeric value (\"%s\") for the parameter \"%s\".",
+                                                             parameter.toString(),
+                                                             parameterName));
+        }
+    }
+
+    protected void checkRMHostname(String rmHostname) {
+        if (rmHostname == null) {
+            throw new IllegalArgumentException("The resource manager hostname must be specified");
+        }
+        if (rmHostname.contains("/")) {
+            throw new IllegalArgumentException(String.format("Invalid hostname %s (hostname should not contains '/').",
+                                                             rmHostname));
+        }
+    }
 }

--- a/infrastructures/infrastructure-common/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/util/LinuxInitScriptGenerator.java
+++ b/infrastructures/infrastructure-common/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/util/LinuxInitScriptGenerator.java
@@ -37,8 +37,6 @@ public class LinuxInitScriptGenerator {
 
     private static final Logger logger = Logger.getLogger(LinuxInitScriptGenerator.class);
 
-    private List<String> commands = new ArrayList<>();
-
     private static Configuration nsConfig;
 
     static {
@@ -68,8 +66,7 @@ public class LinuxInitScriptGenerator {
     public List<String> buildScript(String instanceId, String rmUrlToUse, String rmHostname, String nodeJarUrl,
             String instanceTagNodeProperty, String additionalProperties, String nsName, String nodeName,
             int numberOfNodesPerInstance) {
-
-        commands.clear();
+        List<String> commands = new ArrayList<>();
 
         if (nsConfig.getBoolean(NSProperties.JRE_INSTALL)) {
             commands.add(nsConfig.getString(NSProperties.JRE_INSTALL_COMMAND));
@@ -91,7 +88,7 @@ public class LinuxInitScriptGenerator {
         return commands;
     }
 
-    public String generateNodeDownloadCommand(String nodeJarUrl) {
+    public static String generateNodeDownloadCommand(String nodeJarUrl) {
         return "wget -nv " + nodeJarUrl;
     }
 
@@ -121,11 +118,11 @@ public class LinuxInitScriptGenerator {
                nsConfig.getString(NSProperties.DEFAULT_SUFFIX_CONNECTOR_IAAS_URL);
     }
 
-    public String generateDefaultDownloadCommand(String rmHostname) {
+    public static String generateDefaultDownloadCommand(String rmHostname) {
         return generateNodeDownloadCommand(generateDefaultNodeJarURL(rmHostname));
     }
 
-    public String generateDefaultNodeJarURL(String rmHostname) {
+    public static String generateDefaultNodeJarURL(String rmHostname) {
         return rmHostname + nsConfig.getString(NSProperties.DEFAULT_SUFFIX_RM_TO_NODEJAR_URL);
     }
 }

--- a/infrastructures/infrastructure-gce/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/GCEInfrastructure.java
+++ b/infrastructures/infrastructure-gce/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/GCEInfrastructure.java
@@ -222,13 +222,7 @@ public class GCEInfrastructure extends AbstractAddonInfrastructure {
         }
         // rmHostname
         parameterIndex++;
-        if (parameters[parameterIndex] == null) {
-            throw new IllegalArgumentException("The resource manager hostname must be specified");
-        }
-        if (parameters[parameterIndex].toString().contains("/")) {
-            throw new IllegalArgumentException(String.format("Invalid hostname %s (hostname should not contains '/').",
-                                                             parameters[parameterIndex]));
-        }
+        checkRMHostname(parameters[parameterIndex].toString());
         // connectorIaasURL
         parameterIndex++;
         if (parameters[parameterIndex] == null) {
@@ -248,16 +242,6 @@ public class GCEInfrastructure extends AbstractAddonInfrastructure {
         parameterIndex++;
         if (parameters[parameterIndex] == null) {
             throw new IllegalArgumentException("The node timeout must be specified");
-        }
-    }
-
-    private int parseIntParameter(String parameterName, Object parameter) {
-        try {
-            return Integer.parseInt(parameter.toString().trim());
-        } catch (NumberFormatException e) {
-            throw new IllegalArgumentException(String.format("Non numeric value (\"%s\") for the parameter \"%s\".",
-                                                             parameter.toString(),
-                                                             parameterName));
         }
     }
 

--- a/infrastructures/infrastructure-gce/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/GCEInfrastructure.java
+++ b/infrastructures/infrastructure-gce/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/GCEInfrastructure.java
@@ -427,11 +427,6 @@ public class GCEInfrastructure extends AbstractAddonInfrastructure {
         return false;
     }
 
-    private boolean existRegisteredNodesOnInstance(String instanceTag) {
-        nodesPerInstance = getNodesPerInstancesMap();
-        return nodesPerInstance.get(instanceTag) != null && !nodesPerInstance.get(instanceTag).isEmpty();
-    }
-
     private void terminateInstance(String infrastructureId, String instanceTag) {
         nodeSource.executeInParallel(() -> {
             writeDeletingLock.lock();


### PR DESCRIPTION
- [feat] support dynamic policy.
- [feat] declare nodes as deploying before connected to RM. (currently dynamicPolicy never reuse the created instances without nodes, i.e., DOWN nodes)
- [feat] when all the nodes of an instance become lost, remove the instance.
- [fix] always remove the created instances when shutdown an aws node source and when shutdown PA server
- [fix] LinuxInitScriptGenerator: move the LinuxInitScriptGenerator field commands to a local var in the method buildScript to avoid the synchronize usage issue. (The reason of not using diff LinuxInitScript object to fix this issue is to avoid too much redundant load NSConfig)
- [minor] improve parameters description, order, and value checking
- [minor] disable to configure the parameter spotPrice for the moment, because we don't yet have a checking mechanism for it now, but it may cause the RM portal blocked (hanging in createInstance).