### PR TITLE
fix: retrieve the instanceId locally

### DIFF
--- a/infrastructures/infrastructure-aws-ec2/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/AWSEC2Infrastructure.java
+++ b/infrastructures/infrastructure-aws-ec2/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/AWSEC2Infrastructure.java
@@ -52,7 +52,7 @@ import lombok.Getter;
 public class AWSEC2Infrastructure extends AbstractAddonInfrastructure {
 
     @Getter
-    public final String instanceIdNodeProperty = "instanceId";
+    private final String instanceIdNodeProperty = "instanceId";
 
     public static final String INFRASTRUCTURE_TYPE = "aws-ec2";
 

--- a/infrastructures/infrastructure-aws-ec2/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/AWSEC2Infrastructure.java
+++ b/infrastructures/infrastructure-aws-ec2/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/AWSEC2Infrastructure.java
@@ -37,7 +37,6 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
 import org.apache.log4j.Logger;
-import org.objectweb.proactive.core.ProActiveException;
 import org.objectweb.proactive.core.node.Node;
 import org.ow2.proactive.resourcemanager.exception.RMException;
 import org.ow2.proactive.resourcemanager.nodesource.common.Configurable;
@@ -47,10 +46,13 @@ import org.ow2.proactive.resourcemanager.utils.RMNodeStarter;
 
 import com.google.common.collect.Maps;
 
+import lombok.Getter;
+
 
 public class AWSEC2Infrastructure extends AbstractAddonInfrastructure {
 
-    public static final String INSTANCE_ID_NODE_PROPERTY = "instanceId";
+    @Getter
+    public final String instanceIdNodeProperty = "instanceId";
 
     public static final String INFRASTRUCTURE_TYPE = "aws-ec2";
 
@@ -405,7 +407,7 @@ public class AWSEC2Infrastructure extends AbstractAddonInfrastructure {
                                                                         getRmUrl(),
                                                                         rmHostname,
                                                                         nodeJarURL,
-                                                                        INSTANCE_ID_NODE_PROPERTY,
+                                                                        instanceIdNodeProperty,
                                                                         additionalProperties,
                                                                         nodeSource.getName(),
                                                                         baseNodeName,
@@ -604,16 +606,6 @@ public class AWSEC2Infrastructure extends AbstractAddonInfrastructure {
         } catch (UnknownHostException e) {
             logger.warn(e);
             return "localhost";
-        }
-    }
-
-    @Override
-    protected String getInstanceIdProperty(Node node) throws RMException {
-        try {
-
-            return node.getProperty(INSTANCE_ID_NODE_PROPERTY);
-        } catch (ProActiveException e) {
-            throw new RMException(e);
         }
     }
 

--- a/infrastructures/infrastructure-aws-ec2/src/test/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/AWSEC2InfrastructureTest.java
+++ b/infrastructures/infrastructure-aws-ec2/src/test/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/AWSEC2InfrastructureTest.java
@@ -378,6 +378,9 @@ public class AWSEC2InfrastructureTest {
 
     @Test
     public void testRemoveNode() throws ProActiveException, RMException {
+        final String instanceId = "instance-id";
+        final String nodeName = "region__" + instanceId + "_0";
+        final String instanceIdWithRegion = "region/" + instanceId;
 
         awsec2Infrastructure.configure(AWS_KEY,
                                        AWS_SECRET_KEY,
@@ -402,21 +405,19 @@ public class AWSEC2InfrastructureTest {
 
         when(nodeSource.getName()).thenReturn(INFRASTRUCTURE_ID);
 
-        when(node.getProperty(AWSEC2Infrastructure.INSTANCE_ID_NODE_PROPERTY)).thenReturn("123");
-
         when(node.getNodeInformation()).thenReturn(nodeInformation);
 
         when(node.getProActiveRuntime()).thenReturn(proActiveRuntime);
 
-        when(nodeInformation.getName()).thenReturn("nodename");
+        when(nodeInformation.getName()).thenReturn(nodeName);
 
-        awsec2Infrastructure.getNodesPerInstancesMap().put("123", Sets.newHashSet("nodename"));
+        awsec2Infrastructure.getNodesPerInstancesMap().put(instanceIdWithRegion, Sets.newHashSet(nodeName));
 
         awsec2Infrastructure.removeNode(node);
 
-        verify(proActiveRuntime).killNode("nodename");
+        verify(proActiveRuntime).killNode(nodeName);
 
-        verify(connectorIaasController).terminateInstance(INFRASTRUCTURE_ID, "123");
+        verify(connectorIaasController).terminateInstance(INFRASTRUCTURE_ID, instanceIdWithRegion);
 
         assertThat(awsec2Infrastructure.getNodesPerInstancesMap().isEmpty(), is(true));
 
@@ -446,7 +447,7 @@ public class AWSEC2InfrastructureTest {
 
         awsec2Infrastructure.connectorIaasController = connectorIaasController;
 
-        when(node.getProperty(AWSEC2Infrastructure.INSTANCE_ID_NODE_PROPERTY)).thenReturn("123");
+        when(node.getProperty(awsec2Infrastructure.instanceIdNodeProperty)).thenReturn("123");
 
         when(node.getNodeInformation()).thenReturn(nodeInformation);
 

--- a/infrastructures/infrastructure-aws-ec2/src/test/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/AWSEC2InfrastructureTest.java
+++ b/infrastructures/infrastructure-aws-ec2/src/test/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/AWSEC2InfrastructureTest.java
@@ -447,7 +447,7 @@ public class AWSEC2InfrastructureTest {
 
         awsec2Infrastructure.connectorIaasController = connectorIaasController;
 
-        when(node.getProperty(awsec2Infrastructure.instanceIdNodeProperty)).thenReturn("123");
+        when(node.getProperty(awsec2Infrastructure.getInstanceIdNodeProperty())).thenReturn("123");
 
         when(node.getNodeInformation()).thenReturn(nodeInformation);
 

--- a/infrastructures/infrastructure-azure/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/AzureInfrastructure.java
+++ b/infrastructures/infrastructure-azure/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/AzureInfrastructure.java
@@ -37,11 +37,12 @@ import java.util.Set;
 import java.util.UUID;
 
 import org.apache.log4j.Logger;
-import org.objectweb.proactive.core.ProActiveException;
 import org.objectweb.proactive.core.node.Node;
 import org.ow2.proactive.resourcemanager.exception.RMException;
 import org.ow2.proactive.resourcemanager.nodesource.common.Configurable;
 import org.ow2.proactive.resourcemanager.nodesource.infrastructure.util.LinuxInitScriptGenerator;
+
+import lombok.Getter;
 
 
 public class AzureInfrastructure extends AbstractAddonInfrastructure {
@@ -52,7 +53,8 @@ public class AzureInfrastructure extends AbstractAddonInfrastructure {
 
     public static final String LINUX = "linux";
 
-    public static final String INSTANCE_ID_NODE_PROPERTY = "instanceId";
+    @Getter
+    public final String instanceIdNodeProperty = "instanceId";
 
     public static final String INFRASTRUCTURE_TYPE = "azure";
 
@@ -130,16 +132,15 @@ public class AzureInfrastructure extends AbstractAddonInfrastructure {
 
     private static final String WGET_DOWNLOAD_CMD = "wget -nv " + RM_HTTP_URL_PATTERN + "/rest/node.jar";
 
-    private static final String START_NODE_CMD = "java -jar node.jar -Dproactive.pamr.router.address=" +
-                                                 RM_HTTP_URL_PATTERN + " -D" + INSTANCE_ID_NODE_PROPERTY + "=" +
-                                                 INSTANCE_ID_PATTERN + " " + ADDITIONAL_PROPERTIES_PATTERN + " -r " +
-                                                 RM_URL_PATTERN + " -s " + NODESOURCE_NAME_PATTERN + " -w " +
-                                                 NUMBER_OF_NODES_PATTERN;
+    private final String START_NODE_CMD = "java -jar node.jar -Dproactive.pamr.router.address=" + RM_HTTP_URL_PATTERN +
+                                          " -D" + instanceIdNodeProperty + "=" + INSTANCE_ID_PATTERN + " " +
+                                          ADDITIONAL_PROPERTIES_PATTERN + " -r " + RM_URL_PATTERN + " -s " +
+                                          NODESOURCE_NAME_PATTERN + " -w " + NUMBER_OF_NODES_PATTERN;
 
-    private static final String START_NODE_FALLBACK_CMD = "java -jar node.jar -D" + INSTANCE_ID_NODE_PROPERTY + "=" +
-                                                          INSTANCE_ID_PATTERN + " " + ADDITIONAL_PROPERTIES_PATTERN +
-                                                          " -r " + RM_URL_PATTERN + " -s " + NODESOURCE_NAME_PATTERN +
-                                                          " -w " + NUMBER_OF_NODES_PATTERN;
+    private final String START_NODE_FALLBACK_CMD = "java -jar node.jar -D" + instanceIdNodeProperty + "=" +
+                                                   INSTANCE_ID_PATTERN + " " + ADDITIONAL_PROPERTIES_PATTERN + " -r " +
+                                                   RM_URL_PATTERN + " -s " + NODESOURCE_NAME_PATTERN + " -w " +
+                                                   NUMBER_OF_NODES_PATTERN;
 
     private final transient LinuxInitScriptGenerator linuxInitScriptGenerator = new LinuxInitScriptGenerator();
 
@@ -352,7 +353,7 @@ public class AzureInfrastructure extends AbstractAddonInfrastructure {
             List<String> scripts = linuxInitScriptGenerator.buildScript(currentInstanceId,
                                                                         getRmUrl(),
                                                                         rmHttpUrl,
-                                                                        INSTANCE_ID_NODE_PROPERTY,
+                                                                        instanceIdNodeProperty,
                                                                         additionalProperties,
                                                                         nodeSource.getName(),
                                                                         currentInstanceId,
@@ -489,14 +490,4 @@ public class AzureInfrastructure extends AbstractAddonInfrastructure {
                                           .replace(NUMBER_OF_NODES_PATTERN, String.valueOf(numberOfNodesPerInstance));
         }
     }
-
-    @Override
-    protected String getInstanceIdProperty(Node node) throws RMException {
-        try {
-            return node.getProperty(INSTANCE_ID_NODE_PROPERTY);
-        } catch (ProActiveException e) {
-            throw new RMException(e);
-        }
-    }
-
 }

--- a/infrastructures/infrastructure-azure/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/AzureInfrastructure.java
+++ b/infrastructures/infrastructure-azure/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/AzureInfrastructure.java
@@ -54,7 +54,7 @@ public class AzureInfrastructure extends AbstractAddonInfrastructure {
     public static final String LINUX = "linux";
 
     @Getter
-    public final String instanceIdNodeProperty = "instanceId";
+    private final String instanceIdNodeProperty = "instanceId";
 
     public static final String INFRASTRUCTURE_TYPE = "azure";
 

--- a/infrastructures/infrastructure-azure/src/test/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/AzureInfrastructureTest.java
+++ b/infrastructures/infrastructure-azure/src/test/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/AzureInfrastructureTest.java
@@ -311,7 +311,7 @@ public class AzureInfrastructureTest {
 
         azureInfrastructure.connectorIaasController = connectorIaasController;
 
-        when(node.getProperty(azureInfrastructure.instanceIdNodeProperty)).thenReturn("123");
+        when(node.getProperty(azureInfrastructure.getInstanceIdNodeProperty())).thenReturn("123");
 
         when(node.getNodeInformation()).thenReturn(nodeInformation);
 
@@ -363,7 +363,7 @@ public class AzureInfrastructureTest {
 
         azureInfrastructure.connectorIaasController = connectorIaasController;
 
-        when(node.getProperty(azureInfrastructure.instanceIdNodeProperty)).thenReturn("123");
+        when(node.getProperty(azureInfrastructure.getInstanceIdNodeProperty())).thenReturn("123");
 
         when(node.getNodeInformation()).thenReturn(nodeInformation);
 

--- a/infrastructures/infrastructure-azure/src/test/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/AzureInfrastructureTest.java
+++ b/infrastructures/infrastructure-azure/src/test/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/AzureInfrastructureTest.java
@@ -311,7 +311,7 @@ public class AzureInfrastructureTest {
 
         azureInfrastructure.connectorIaasController = connectorIaasController;
 
-        when(node.getProperty(AzureInfrastructure.INSTANCE_ID_NODE_PROPERTY)).thenReturn("123");
+        when(node.getProperty(azureInfrastructure.instanceIdNodeProperty)).thenReturn("123");
 
         when(node.getNodeInformation()).thenReturn(nodeInformation);
 
@@ -363,7 +363,7 @@ public class AzureInfrastructureTest {
 
         azureInfrastructure.connectorIaasController = connectorIaasController;
 
-        when(node.getProperty(AzureInfrastructure.INSTANCE_ID_NODE_PROPERTY)).thenReturn("123");
+        when(node.getProperty(azureInfrastructure.instanceIdNodeProperty)).thenReturn("123");
 
         when(node.getNodeInformation()).thenReturn(nodeInformation);
 

--- a/infrastructures/infrastructure-gce/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/GCEInfrastructure.java
+++ b/infrastructures/infrastructure-gce/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/GCEInfrastructure.java
@@ -57,7 +57,7 @@ public class GCEInfrastructure extends AbstractAddonInfrastructure {
     public static final String INFRASTRUCTURE_TYPE = "google-compute-engine";
 
     @Getter
-    public final String instanceIdNodeProperty = "instanceTag";
+    private final String instanceIdNodeProperty = "instanceTag";
 
     private static final int NUMBER_OF_PARAMETERS = 15;
 

--- a/infrastructures/infrastructure-gce/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/GCEInfrastructure.java
+++ b/infrastructures/infrastructure-gce/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/GCEInfrastructure.java
@@ -56,7 +56,8 @@ public class GCEInfrastructure extends AbstractAddonInfrastructure {
 
     public static final String INFRASTRUCTURE_TYPE = "google-compute-engine";
 
-    public static final String INSTANCE_TAG_NODE_PROPERTY = "instanceTag";
+    @Getter
+    public final String instanceIdNodeProperty = "instanceTag";
 
     private static final int NUMBER_OF_PARAMETERS = 15;
 
@@ -341,7 +342,7 @@ public class GCEInfrastructure extends AbstractAddonInfrastructure {
                                                     getRmUrl(),
                                                     rmHostname,
                                                     nodeJarURL,
-                                                    INSTANCE_TAG_NODE_PROPERTY,
+                                                    instanceIdNodeProperty,
                                                     additionalProperties,
                                                     nodeSource.getName(),
                                                     NODE_NAME_ON_NODE,
@@ -448,15 +449,6 @@ public class GCEInfrastructure extends AbstractAddonInfrastructure {
             writeDeletingLock.unlock();
         }
 
-    }
-
-    @Override
-    protected String getInstanceIdProperty(Node node) throws RMException {
-        try {
-            return node.getProperty(INSTANCE_TAG_NODE_PROPERTY);
-        } catch (ProActiveException e) {
-            throw new RMException(e);
-        }
     }
 
     @Override

--- a/infrastructures/infrastructure-gce/src/test/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/GCEInfrastructureTest.java
+++ b/infrastructures/infrastructure-gce/src/test/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/GCEInfrastructureTest.java
@@ -511,7 +511,7 @@ public class GCEInfrastructureTest {
         gceInfrastructure.connectorIaasController = connectorIaasController;
         final String instanceTag = "instance-tag";
         final String nodeName = "node-name";
-        when(node.getProperty(GCEInfrastructure.INSTANCE_TAG_NODE_PROPERTY)).thenReturn(instanceTag);
+        when(node.getProperty(gceInfrastructure.instanceIdNodeProperty)).thenReturn(instanceTag);
         when(node.getNodeInformation()).thenReturn(nodeInformation);
         when(nodeInformation.getName()).thenReturn(nodeName);
 
@@ -547,7 +547,7 @@ public class GCEInfrastructureTest {
         }).when(nodeSource).executeInParallel(any(Runnable.class));
         final String instanceTag = "instance-tag";
         final String nodeName = "node-name";
-        when(node.getProperty(GCEInfrastructure.INSTANCE_TAG_NODE_PROPERTY)).thenReturn(instanceTag);
+        when(node.getProperty(gceInfrastructure.instanceIdNodeProperty)).thenReturn(instanceTag);
         when(node.getProActiveRuntime()).thenReturn(proActiveRuntime);
         when(node.getNodeInformation()).thenReturn(nodeInformation);
         when(nodeInformation.getName()).thenReturn(nodeName);

--- a/infrastructures/infrastructure-gce/src/test/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/GCEInfrastructureTest.java
+++ b/infrastructures/infrastructure-gce/src/test/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/GCEInfrastructureTest.java
@@ -511,7 +511,7 @@ public class GCEInfrastructureTest {
         gceInfrastructure.connectorIaasController = connectorIaasController;
         final String instanceTag = "instance-tag";
         final String nodeName = "node-name";
-        when(node.getProperty(gceInfrastructure.instanceIdNodeProperty)).thenReturn(instanceTag);
+        when(node.getProperty(gceInfrastructure.getInstanceIdNodeProperty())).thenReturn(instanceTag);
         when(node.getNodeInformation()).thenReturn(nodeInformation);
         when(nodeInformation.getName()).thenReturn(nodeName);
 
@@ -547,7 +547,7 @@ public class GCEInfrastructureTest {
         }).when(nodeSource).executeInParallel(any(Runnable.class));
         final String instanceTag = "instance-tag";
         final String nodeName = "node-name";
-        when(node.getProperty(gceInfrastructure.instanceIdNodeProperty)).thenReturn(instanceTag);
+        when(node.getProperty(gceInfrastructure.getInstanceIdNodeProperty())).thenReturn(instanceTag);
         when(node.getProActiveRuntime()).thenReturn(proActiveRuntime);
         when(node.getNodeInformation()).thenReturn(nodeInformation);
         when(nodeInformation.getName()).thenReturn(nodeName);

--- a/infrastructures/infrastructure-openstack/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/OpenstackInfrastructure.java
+++ b/infrastructures/infrastructure-openstack/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/OpenstackInfrastructure.java
@@ -58,7 +58,7 @@ public class OpenstackInfrastructure extends AbstractAddonInfrastructure {
     private static final int NUMBER_OF_PARAMETERS = 17;
 
     @Getter
-    public final String instanceIdNodeProperty = "instanceTag";
+    private final String instanceIdNodeProperty = "instanceTag";
 
     public static final String INFRASTRUCTURE_TYPE = "openstack-nova";
 

--- a/infrastructures/infrastructure-openstack/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/OpenstackInfrastructure.java
+++ b/infrastructures/infrastructure-openstack/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/OpenstackInfrastructure.java
@@ -33,7 +33,6 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
 import org.apache.log4j.Logger;
-import org.objectweb.proactive.core.ProActiveException;
 import org.objectweb.proactive.core.node.Node;
 import org.objectweb.proactive.core.util.ProActiveCounter;
 import org.ow2.proactive.resourcemanager.exception.RMException;
@@ -41,6 +40,8 @@ import org.ow2.proactive.resourcemanager.nodesource.common.Configurable;
 import org.ow2.proactive.resourcemanager.nodesource.infrastructure.util.LinuxInitScriptGenerator;
 
 import com.google.common.collect.Maps;
+
+import lombok.Getter;
 
 
 /**
@@ -56,7 +57,8 @@ public class OpenstackInfrastructure extends AbstractAddonInfrastructure {
 
     private static final int NUMBER_OF_PARAMETERS = 17;
 
-    public static final String INSTANCE_TAG_NODE_PROPERTY = "instanceTag";
+    @Getter
+    public final String instanceIdNodeProperty = "instanceTag";
 
     public static final String INFRASTRUCTURE_TYPE = "openstack-nova";
 
@@ -323,15 +325,6 @@ public class OpenstackInfrastructure extends AbstractAddonInfrastructure {
     }
 
     @Override
-    protected String getInstanceIdProperty(Node node) throws RMException {
-        try {
-            return node.getProperty(INSTANCE_TAG_NODE_PROPERTY);
-        } catch (ProActiveException e) {
-            throw new RMException(e);
-        }
-    }
-
-    @Override
     public void shutDown() {
         String infrastructureId = getInfrastructureId();
         logger.info("Deleting infrastructure : " + infrastructureId + " and its underlying instances");
@@ -544,7 +537,7 @@ public class OpenstackInfrastructure extends AbstractAddonInfrastructure {
         return linuxInitScriptGenerator.buildScript(instanceTag,
                                                     getRmUrl(),
                                                     rmHostname,
-                                                    INSTANCE_TAG_NODE_PROPERTY,
+                                                    instanceIdNodeProperty,
                                                     additionalProperties,
                                                     nodeSource.getName(),
                                                     nodeName,

--- a/infrastructures/infrastructure-openstack/src/test/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/OpenstackInfrastructureTest.java
+++ b/infrastructures/infrastructure-openstack/src/test/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/OpenstackInfrastructureTest.java
@@ -324,7 +324,7 @@ public class OpenstackInfrastructureTest {
 
         openstackInfrastructure.connectorIaasController = connectorIaasController;
 
-        when(node.getProperty(OpenstackInfrastructure.INSTANCE_TAG_NODE_PROPERTY)).thenReturn("123");
+        when(node.getProperty(openstackInfrastructure.instanceIdNodeProperty)).thenReturn("123");
 
         when(node.getNodeInformation()).thenReturn(nodeInformation);
 
@@ -370,7 +370,7 @@ public class OpenstackInfrastructureTest {
 
         openstackInfrastructure.connectorIaasController = connectorIaasController;
 
-        when(node.getProperty(OpenstackInfrastructure.INSTANCE_TAG_NODE_PROPERTY)).thenReturn("123");
+        when(node.getProperty(openstackInfrastructure.instanceIdNodeProperty)).thenReturn("123");
 
         when(node.getNodeInformation()).thenReturn(nodeInformation);
 

--- a/infrastructures/infrastructure-openstack/src/test/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/OpenstackInfrastructureTest.java
+++ b/infrastructures/infrastructure-openstack/src/test/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/OpenstackInfrastructureTest.java
@@ -324,7 +324,7 @@ public class OpenstackInfrastructureTest {
 
         openstackInfrastructure.connectorIaasController = connectorIaasController;
 
-        when(node.getProperty(openstackInfrastructure.instanceIdNodeProperty)).thenReturn("123");
+        when(node.getProperty(openstackInfrastructure.getInstanceIdNodeProperty())).thenReturn("123");
 
         when(node.getNodeInformation()).thenReturn(nodeInformation);
 
@@ -370,7 +370,7 @@ public class OpenstackInfrastructureTest {
 
         openstackInfrastructure.connectorIaasController = connectorIaasController;
 
-        when(node.getProperty(openstackInfrastructure.instanceIdNodeProperty)).thenReturn("123");
+        when(node.getProperty(openstackInfrastructure.getInstanceIdNodeProperty())).thenReturn("123");
 
         when(node.getNodeInformation()).thenReturn(nodeInformation);
 

--- a/infrastructures/infrastructure-vmware/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/VMWareInfrastructure.java
+++ b/infrastructures/infrastructure-vmware/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/VMWareInfrastructure.java
@@ -42,7 +42,7 @@ import lombok.Getter;
 public class VMWareInfrastructure extends AbstractAddonInfrastructure {
 
     @Getter
-    public final String instanceIdNodeProperty = "instanceId";
+    private final String instanceIdNodeProperty = "instanceId";
 
     public static final String INFRASTRUCTURE_TYPE = "vmware";
 

--- a/infrastructures/infrastructure-vmware/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/VMWareInfrastructure.java
+++ b/infrastructures/infrastructure-vmware/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/VMWareInfrastructure.java
@@ -30,17 +30,19 @@ import java.net.UnknownHostException;
 import java.util.Set;
 
 import org.apache.log4j.Logger;
-import org.objectweb.proactive.core.ProActiveException;
 import org.objectweb.proactive.core.node.Node;
 import org.ow2.proactive.resourcemanager.exception.RMException;
 import org.ow2.proactive.resourcemanager.nodesource.common.Configurable;
 
 import com.google.common.collect.Lists;
 
+import lombok.Getter;
+
 
 public class VMWareInfrastructure extends AbstractAddonInfrastructure {
 
-    public static final String INSTANCE_ID_NODE_PROPERTY = "instanceId";
+    @Getter
+    public final String instanceIdNodeProperty = "instanceId";
 
     public static final String INFRASTRUCTURE_TYPE = "vmware";
 
@@ -302,23 +304,13 @@ public class VMWareInfrastructure extends AbstractAddonInfrastructure {
 
             String protocol = rmUrlToUse.substring(0, rmUrlToUse.indexOf(':')).trim();
             return "java -jar node.jar -Dproactive.communication.protocol=" + protocol +
-                   " -Dproactive.pamr.router.address=" + rmHostname + " -D" + INSTANCE_ID_NODE_PROPERTY + "=" +
+                   " -Dproactive.pamr.router.address=" + rmHostname + " -D" + instanceIdNodeProperty + "=" +
                    instanceId + " " + additionalProperties + " -r " + rmUrlToUse + " -s " + nodeSource.getName() +
                    " -w " + numberOfNodesPerInstance;
         } catch (Exception e) {
             logger.error("Exception when generating the command, fallback on default value", e);
-            return "java -jar node.jar -D" + INSTANCE_ID_NODE_PROPERTY + "=" + instanceId + " " + additionalProperties +
+            return "java -jar node.jar -D" + instanceIdNodeProperty + "=" + instanceId + " " + additionalProperties +
                    " -r " + getRmUrl() + " -s " + nodeSource.getName() + " -w " + numberOfNodesPerInstance;
         }
     }
-
-    @Override
-    protected String getInstanceIdProperty(Node node) throws RMException {
-        try {
-            return node.getProperty(INSTANCE_ID_NODE_PROPERTY);
-        } catch (ProActiveException e) {
-            throw new RMException(e);
-        }
-    }
-
 }

--- a/infrastructures/infrastructure-vmware/src/test/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/VMWareInfrastructureTest.java
+++ b/infrastructures/infrastructure-vmware/src/test/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/VMWareInfrastructureTest.java
@@ -377,7 +377,7 @@ public class VMWareInfrastructureTest {
 
         vmwareInfrastructure.connectorIaasController = connectorIaasController;
 
-        when(node.getProperty(vmwareInfrastructure.instanceIdNodeProperty)).thenReturn("123");
+        when(node.getProperty(vmwareInfrastructure.getInstanceIdNodeProperty())).thenReturn("123");
 
         when(node.getNodeInformation()).thenReturn(nodeInformation);
 
@@ -420,7 +420,7 @@ public class VMWareInfrastructureTest {
 
         vmwareInfrastructure.connectorIaasController = connectorIaasController;
 
-        when(node.getProperty(vmwareInfrastructure.instanceIdNodeProperty)).thenReturn("123");
+        when(node.getProperty(vmwareInfrastructure.getInstanceIdNodeProperty())).thenReturn("123");
 
         when(node.getNodeInformation()).thenReturn(nodeInformation);
 

--- a/infrastructures/infrastructure-vmware/src/test/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/VMWareInfrastructureTest.java
+++ b/infrastructures/infrastructure-vmware/src/test/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/VMWareInfrastructureTest.java
@@ -377,7 +377,7 @@ public class VMWareInfrastructureTest {
 
         vmwareInfrastructure.connectorIaasController = connectorIaasController;
 
-        when(node.getProperty(VMWareInfrastructure.INSTANCE_ID_NODE_PROPERTY)).thenReturn("123");
+        when(node.getProperty(vmwareInfrastructure.instanceIdNodeProperty)).thenReturn("123");
 
         when(node.getNodeInformation()).thenReturn(nodeInformation);
 
@@ -420,7 +420,7 @@ public class VMWareInfrastructureTest {
 
         vmwareInfrastructure.connectorIaasController = connectorIaasController;
 
-        when(node.getProperty(VMWareInfrastructure.INSTANCE_ID_NODE_PROPERTY)).thenReturn("123");
+        when(node.getProperty(vmwareInfrastructure.instanceIdNodeProperty)).thenReturn("123");
 
         when(node.getNodeInformation()).thenReturn(nodeInformation);
 


### PR DESCRIPTION
Use **locally** persisted instanceId-nodeNameSet map to retrieve the instanceId instead of getting it from **remote** node. 

The old behavior sometime cause the error during removeNode, because node.jar process may be terminated first by RMCore.