### PR TITLE
minor fix for infrastructure parameters

### DIFF
--- a/infrastructures/infrastructure-aws-ec2/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/AWSEC2Infrastructure.java
+++ b/infrastructures/infrastructure-aws-ec2/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/AWSEC2Infrastructure.java
@@ -191,27 +191,27 @@ public class AWSEC2Infrastructure extends AbstractAddonInfrastructure {
         }
         int parameterIndex = 0;
         // awsKey
-        if (parameters[parameterIndex] == null) {
+        if (parameterValueIsNotSpecified(parameters[parameterIndex])) {
             throw new IllegalArgumentException("AWS access key ID must be specified");
         }
         parameterIndex++;
         // awsSecretKey
-        if (parameters[parameterIndex] == null) {
+        if (parameterValueIsNotSpecified(parameters[parameterIndex])) {
             throw new IllegalArgumentException("AWS secret access key must be specified");
         }
         parameterIndex++;
         // numberOfInstances
-        if (parameters[parameterIndex] == null) {
+        if (parameterValueIsNotSpecified(parameters[parameterIndex])) {
             throw new IllegalArgumentException("The number of instances to create must be specified");
         }
         parameterIndex++;
         // numberOfNodesPerInstance
-        if (parameters[parameterIndex] == null) {
+        if (parameterValueIsNotSpecified(parameters[parameterIndex])) {
             throw new IllegalArgumentException("The number of nodes per instance to deploy must be specified");
         }
         parameterIndex++;
         // image
-        if (parameters[parameterIndex] == null) {
+        if (parameterValueIsNotSpecified(parameters[parameterIndex])) {
             parameters[parameterIndex] = DEFAULT_IMAGE;
         }
         if (!parameters[parameterIndex].toString().contains("/")) {
@@ -220,7 +220,7 @@ public class AWSEC2Infrastructure extends AbstractAddonInfrastructure {
         }
         parameterIndex++;
         // vmUsername
-        if (parameters[parameterIndex] == null) {
+        if (parameterValueIsNotSpecified(parameters[parameterIndex])) {
             parameters[parameterIndex] = DEFAULT_VM_USERNAME;
         }
         parameterIndex++;
@@ -235,12 +235,12 @@ public class AWSEC2Infrastructure extends AbstractAddonInfrastructure {
         }
         parameterIndex++;
         // ram
-        if (parameters[parameterIndex] == null) {
+        if (parameterValueIsNotSpecified(parameters[parameterIndex])) {
             parameters[parameterIndex] = DEFAULT_RAM;
         }
         parameterIndex++;
         // cores
-        if (parameters[parameterIndex] == null) {
+        if (parameterValueIsNotSpecified(parameters[parameterIndex])) {
             parameters[parameterIndex] = DEFAULT_CORES;
         }
         parameterIndex++;
@@ -264,12 +264,12 @@ public class AWSEC2Infrastructure extends AbstractAddonInfrastructure {
         checkRMHostname(parameters[parameterIndex].toString());
         parameterIndex++;
         // connectorIaasURL
-        if (parameters[parameterIndex] == null) {
+        if (parameterValueIsNotSpecified(parameters[parameterIndex])) {
             throw new IllegalArgumentException("The connector-iaas URL must be specified");
         }
         parameterIndex++;
         // nodeJarURL
-        if (parameters[parameterIndex] == null) {
+        if (parameterValueIsNotSpecified(parameters[parameterIndex])) {
             throw new IllegalArgumentException("The URL for downloading the node jar must be specified");
         }
         parameterIndex++;
@@ -279,8 +279,8 @@ public class AWSEC2Infrastructure extends AbstractAddonInfrastructure {
         }
         parameterIndex++;
         // nodeTimeout
-        if (parameters[parameterIndex] == null) {
-            throw new IllegalArgumentException("The node timeout must be specified");
+        if (parameterValueIsNotSpecified(parameters[parameterIndex])) {
+            parameters[parameterIndex] = DEFAULT_NODE_TIMEOUT;
         }
     }
 

--- a/infrastructures/infrastructure-aws-ec2/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/AWSEC2Infrastructure.java
+++ b/infrastructures/infrastructure-aws-ec2/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/AWSEC2Infrastructure.java
@@ -160,10 +160,10 @@ public class AWSEC2Infrastructure extends AbstractAddonInfrastructure {
     protected String rmHostname = generateDefaultRMHostname();
 
     @Configurable(description = "Connector-iaas URL", sectionSelector = 4, important = true)
-    protected String connectorIaasURL = "http://" + generateDefaultRMHostname() + ":8080/connector-iaas";
+    protected String connectorIaasURL = LinuxInitScriptGenerator.generateDefaultIaasConnectorURL(generateDefaultRMHostname());
 
     @Configurable(description = "URL used to download the node jar on the VM", sectionSelector = 4, important = true)
-    protected String nodeJarURL = LinuxInitScriptGenerator.generateDefaultNodeJarURL(rmHostname);
+    protected String nodeJarURL = LinuxInitScriptGenerator.generateDefaultNodeJarURL(generateDefaultRMHostname());
 
     @Configurable(description = "(optional) Additional Java command properties (e.g. \"-Dpropertyname=propertyvalue\")", sectionSelector = 5)
     protected String additionalProperties = "";
@@ -545,16 +545,6 @@ public class AWSEC2Infrastructure extends AbstractAddonInfrastructure {
     @Override
     public String toString() {
         return getDescription();
-    }
-
-    private String generateDefaultRMHostname() {
-        try {
-            // best effort, may not work for all machines
-            return InetAddress.getLocalHost().getCanonicalHostName();
-        } catch (UnknownHostException e) {
-            logger.warn(e);
-            return "localhost";
-        }
     }
 
     private void persistKeyPairInfo(final SimpleImmutableEntry<String, String> keyPair) {

--- a/infrastructures/infrastructure-aws-ec2/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/AWSEC2Infrastructure.java
+++ b/infrastructures/infrastructure-aws-ec2/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/AWSEC2Infrastructure.java
@@ -85,9 +85,7 @@ public class AWSEC2Infrastructure extends AbstractAddonInfrastructure {
 
     private boolean isCreatedInfrastructure = false;
 
-    /**
-     * The index of the infrastructure configurable parameters.
-     */
+    // The index of the infrastructure configurable parameters.
     protected enum Indexes {
         AWS_KEY(0),
         AWS_SECRET_KEY(1),
@@ -165,7 +163,7 @@ public class AWSEC2Infrastructure extends AbstractAddonInfrastructure {
     protected String connectorIaasURL = "http://" + generateDefaultRMHostname() + ":8080/connector-iaas";
 
     @Configurable(description = "URL used to download the node jar on the VM", sectionSelector = 4, important = true)
-    protected String nodeJarURL = linuxInitScriptGenerator.generateDefaultNodeJarURL(rmHostname);
+    protected String nodeJarURL = LinuxInitScriptGenerator.generateDefaultNodeJarURL(rmHostname);
 
     @Configurable(description = "(optional) Additional Java command properties (e.g. \"-Dpropertyname=propertyvalue\")", sectionSelector = 5)
     protected String additionalProperties = "";

--- a/infrastructures/infrastructure-azure/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/AzureInfrastructure.java
+++ b/infrastructures/infrastructure-azure/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/AzureInfrastructure.java
@@ -30,7 +30,6 @@ import static org.ow2.proactive.resourcemanager.nodesource.infrastructure.Additi
 
 import java.io.IOException;
 import java.net.InetAddress;
-import java.net.URL;
 import java.net.UnknownHostException;
 import java.security.KeyException;
 import java.time.LocalDateTime;
@@ -95,7 +94,7 @@ public class AzureInfrastructure extends AbstractAddonInfrastructure {
 
     private final static int GRAPH_ENDPOINT_INDEX = 7;
 
-    private final static int RM_HTTP_URL_INDEX = 8;
+    private final static int RM_HOSTNAME_INDEX = 8;
 
     private final static int CONNECTOR_IAAS_URL_INDEX = 9;
 
@@ -119,7 +118,7 @@ public class AzureInfrastructure extends AbstractAddonInfrastructure {
 
     private final static int NUMBER_OF_NODES_PER_INSTANCE_INDEX = 19;
 
-    private final static int DOWNLOAD_COMMAND_INDEX = 20;
+    private final static int NODE_JAR_URL_INDEX = 20;
 
     private final static int PRIVATE_NETWORK_CIDR_INDEX = 21;
 
@@ -204,11 +203,11 @@ public class AzureInfrastructure extends AbstractAddonInfrastructure {
     @Configurable(description = "Optional graph endpoint from specific Azure environment", sectionSelector = 2)
     protected String graphEndpoint = null;
 
-    @Configurable(description = "Resource manager HTTP URL (must be accessible from nodes)", sectionSelector = 3, important = true)
-    protected String rmHttpUrl = generateDefaultHttpRMUrl();
+    @Configurable(description = "Resource manager hostname or ip address (must be accessible from nodes)", sectionSelector = 3, important = true)
+    protected String rmHostname = generateDefaultRMHostname();
 
     @Configurable(description = "Connector-iaas URL", sectionSelector = 3, important = true)
-    protected String connectorIaasURL = generateDefaultHttpRMUrl() + "/connector-iaas";
+    protected String connectorIaasURL = LinuxInitScriptGenerator.generateDefaultIaasConnectorURL(generateDefaultRMHostname());
 
     @Configurable(description = "Image (name or key)", sectionSelector = 5, important = true)
     protected String image = null;
@@ -240,8 +239,12 @@ public class AzureInfrastructure extends AbstractAddonInfrastructure {
     @Configurable(description = "Total nodes to create per instance", sectionSelector = 4, important = true)
     protected int numberOfNodesPerInstance = 1;
 
-    @Configurable(description = "Command used to download the worker jar (a default command will be generated for the specified image OS type)", sectionSelector = 7)
+    //    @Configurable(description = "Command used to download the worker jar (a default command will be generated for the specified image OS type)", sectionSelector = 7)
+    // The variable is not longer effectively used, but it's kept temporarily to facilitate future support of deploying nodes on windows os VM
     protected String downloadCommand = null;
+
+    @Configurable(description = "URL used to download the node jar on the VM", sectionSelector = 7, important = true)
+    protected String nodeJarURL = LinuxInitScriptGenerator.generateDefaultNodeJarURL(generateDefaultRMHostname());
 
     @Configurable(description = "Optional network CIDR to attach with new VM(s) (by default: '10.0.0.0/24')", sectionSelector = 6)
     protected String privateNetworkCIDR = null;
@@ -284,7 +287,7 @@ public class AzureInfrastructure extends AbstractAddonInfrastructure {
         this.managementEndpoint = getParameter(parameters, MANAGEMENT_ENDPOINT_INDEX);
         this.resourceManagerEndpoint = getParameter(parameters, RESOURCE_MANAGER_ENDPOINT_INDEX);
         this.graphEndpoint = getParameter(parameters, GRAPH_ENDPOINT_INDEX);
-        this.rmHttpUrl = getParameter(parameters, RM_HTTP_URL_INDEX);
+        this.rmHostname = getParameter(parameters, RM_HOSTNAME_INDEX);
         this.connectorIaasURL = getParameter(parameters, CONNECTOR_IAAS_URL_INDEX);
         this.image = getParameter(parameters, IMAGE_INDEX);
         this.imageOSType = getParameter(parameters, IMAGE_OS_TYPE_INDEX).toLowerCase();
@@ -296,7 +299,7 @@ public class AzureInfrastructure extends AbstractAddonInfrastructure {
         this.region = getParameter(parameters, REGION_INDEX);
         this.numberOfInstances = Integer.parseInt(getParameter(parameters, NUMBER_OF_INSTANCES_INDEX));
         this.numberOfNodesPerInstance = Integer.parseInt(getParameter(parameters, NUMBER_OF_NODES_PER_INSTANCE_INDEX));
-        this.downloadCommand = getParameter(parameters, DOWNLOAD_COMMAND_INDEX);
+        this.nodeJarURL = getParameter(parameters, NODE_JAR_URL_INDEX);
         this.privateNetworkCIDR = getParameter(parameters, PRIVATE_NETWORK_CIDR_INDEX);
         this.staticPublicIP = Boolean.parseBoolean(getParameter(parameters, STATIC_PUBLIC_IP_INDEX));
         this.additionalProperties = getParameter(parameters, ADDITIONAL_PROPERTIES_INDEX);
@@ -323,8 +326,8 @@ public class AzureInfrastructure extends AbstractAddonInfrastructure {
         throwIllegalArgumentExceptionIfNull(parameters[CLIENT_ID_INDEX], "Azure clientId must be specified");
         throwIllegalArgumentExceptionIfNull(parameters[SECRET_INDEX], "Azure secret key must be specified");
         throwIllegalArgumentExceptionIfNull(parameters[DOMAIN_INDEX], "Azure domain or tenantId must be specified");
-        throwIllegalArgumentExceptionIfNull(parameters[RM_HTTP_URL_INDEX],
-                                            "The Resource manager HTTP URL must be specified");
+        throwIllegalArgumentExceptionIfNull(parameters[RM_HOSTNAME_INDEX],
+                                            "The Resource manager hostname must be specified");
         throwIllegalArgumentExceptionIfNull(parameters[CONNECTOR_IAAS_URL_INDEX],
                                             "The connector-iaas URL must be specified");
         throwIllegalArgumentExceptionIfNull(parameters[IMAGE_INDEX], "The image id must be specified");
@@ -341,10 +344,12 @@ public class AzureInfrastructure extends AbstractAddonInfrastructure {
                                             "The number of instances to create must be specified");
         throwIllegalArgumentExceptionIfNull(parameters[NUMBER_OF_NODES_PER_INSTANCE_INDEX],
                                             "The number of nodes per instance to deploy must be specified");
-        if (parameters[DOWNLOAD_COMMAND_INDEX] == null || getParameter(parameters, DOWNLOAD_COMMAND_INDEX).isEmpty()) {
-            parameters[DOWNLOAD_COMMAND_INDEX] = generateDefaultDownloadCommand((String) parameters[IMAGE_OS_TYPE_INDEX],
-                                                                                (String) parameters[RM_HTTP_URL_INDEX]);
-        }
+        //        if (parameters[DOWNLOAD_COMMAND_INDEX] == null || getParameter(parameters, DOWNLOAD_COMMAND_INDEX).isEmpty()) {
+        //            parameters[DOWNLOAD_COMMAND_INDEX] = generateDefaultDownloadCommand((String) parameters[IMAGE_OS_TYPE_INDEX],
+        //                                                                                (String) parameters[RM_HTTP_URL_INDEX]);
+        //        }
+        throwIllegalArgumentExceptionIfNull(parameters[NODE_JAR_URL_INDEX],
+                                            "URL used to download the node jar must be specified");
         if (parameters[ADDITIONAL_PROPERTIES_INDEX] == null) {
             parameters[ADDITIONAL_PROPERTIES_INDEX] = "";
         }
@@ -532,7 +537,8 @@ public class AzureInfrastructure extends AbstractAddonInfrastructure {
             try {
                 List<String> scripts = linuxInitScriptGenerator.buildScript(currentInstanceId,
                                                                             getRmUrl(),
-                                                                            rmHttpUrl,
+                                                                            rmHostname,
+                                                                            nodeJarURL,
                                                                             instanceIdNodeProperty,
                                                                             additionalProperties,
                                                                             nodeSource.getName(),
@@ -657,7 +663,6 @@ public class AzureInfrastructure extends AbstractAddonInfrastructure {
 
     private String generateStartNodeCommand(String instanceId) {
         try {
-            String rmHostname = new URL(rmHttpUrl).getHost();
             return START_NODE_CMD.replace(RM_HTTP_URL_PATTERN, rmHostname)
                                  .replace(INSTANCE_ID_PATTERN, instanceId)
                                  .replace(ADDITIONAL_PROPERTIES_PATTERN, additionalProperties)

--- a/infrastructures/infrastructure-azure/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/AzureInfrastructure.java
+++ b/infrastructures/infrastructure-azure/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/AzureInfrastructure.java
@@ -344,6 +344,7 @@ public class AzureInfrastructure extends AbstractAddonInfrastructure {
                                             "The number of instances to create must be specified");
         throwIllegalArgumentExceptionIfNull(parameters[NUMBER_OF_NODES_PER_INSTANCE_INDEX],
                                             "The number of nodes per instance to deploy must be specified");
+        // The variable downloadCommand is not longer effectively used, but it's kept temporarily to facilitate future support of deploying nodes on windows os VM
         //        if (parameters[DOWNLOAD_COMMAND_INDEX] == null || getParameter(parameters, DOWNLOAD_COMMAND_INDEX).isEmpty()) {
         //            parameters[DOWNLOAD_COMMAND_INDEX] = generateDefaultDownloadCommand((String) parameters[IMAGE_OS_TYPE_INDEX],
         //                                                                                (String) parameters[RM_HTTP_URL_INDEX]);

--- a/infrastructures/infrastructure-azure/src/test/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/AzureInfrastructureTest.java
+++ b/infrastructures/infrastructure-azure/src/test/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/AzureInfrastructureTest.java
@@ -101,8 +101,8 @@ public class AzureInfrastructureTest {
         assertThat(azureInfrastructure.managementEndpoint, is(nullValue()));
         assertThat(azureInfrastructure.resourceManagerEndpoint, is(nullValue()));
         assertThat(azureInfrastructure.graphEndpoint, is(nullValue()));
-        assertThat(azureInfrastructure.rmHttpUrl, is(not(nullValue())));
-        assertThat(azureInfrastructure.connectorIaasURL, is(azureInfrastructure.rmHttpUrl + "/connector-iaas"));
+        assertThat(azureInfrastructure.rmHostname, is(not(nullValue())));
+        assertThat(azureInfrastructure.connectorIaasURL, is(not(nullValue())));
         assertThat(azureInfrastructure.image, is(nullValue()));
         assertTrue(azureInfrastructure.imageOSType.equals("linux"));
         assertThat(azureInfrastructure.vmSizeType, is(nullValue()));
@@ -113,7 +113,7 @@ public class AzureInfrastructureTest {
         assertThat(azureInfrastructure.region, is(nullValue()));
         assertThat(azureInfrastructure.numberOfInstances, is(1));
         assertThat(azureInfrastructure.numberOfNodesPerInstance, is(1));
-        assertThat(azureInfrastructure.downloadCommand, is(nullValue()));
+        assertThat(azureInfrastructure.nodeJarURL, is(not(nullValue())));
         assertThat(azureInfrastructure.privateNetworkCIDR, is(nullValue()));
         assertThat(azureInfrastructure.staticPublicIP, is(true));
         assertThat(azureInfrastructure.additionalProperties,
@@ -134,7 +134,7 @@ public class AzureInfrastructureTest {
                                           "managementEndpoint",
                                           "resourceManagerEndpoint",
                                           "graphEndpoint",
-                                          "http://test.activeeon.com:8080",
+                                          "test.activeeon.com",
                                           "http://localhost:8088/connector-iaas",
                                           "image",
                                           "linux",
@@ -146,7 +146,7 @@ public class AzureInfrastructureTest {
                                           "region",
                                           "2",
                                           "3",
-                                          "wget -nv test.activeeon.com/rest/node.jar",
+                                          "test.activeeon.com/rest/node.jar",
                                           "192.168.1.0/24",
                                           true,
                                           "-Dnew=value",
@@ -185,7 +185,7 @@ public class AzureInfrastructureTest {
                                       "managementEndpoint",
                                       "resourceManagerEndpoint",
                                       "graphEndpoint",
-                                      "http://test.activeeon.com:8080",
+                                      "test.activeeon.com",
                                       "http://localhost:8088/connector-iaas",
                                       null,
                                       "linux",
@@ -197,7 +197,7 @@ public class AzureInfrastructureTest {
                                       "region",
                                       "2",
                                       "3",
-                                      "wget -nv test.activeeon.com/rest/node.jar",
+                                      "test.activeeon.com/rest/node.jar",
                                       "192.168.1.0/24",
                                       true,
                                       "-Dnew=value",
@@ -224,7 +224,7 @@ public class AzureInfrastructureTest {
                                       "managementEndpoint",
                                       "resourceManagerEndpoint",
                                       "graphEndpoint",
-                                      "http://test.activeeon.com:8080",
+                                      "test.activeeon.com",
                                       "http://localhost:8088/connector-iaas",
                                       "image",
                                       "windows",
@@ -236,7 +236,7 @@ public class AzureInfrastructureTest {
                                       "region",
                                       "2",
                                       "3",
-                                      null,
+                                      "http://localhost:8088/rest/node.jar",
                                       "192.168.1.0/24",
                                       true,
                                       "-Dnew=value",

--- a/infrastructures/infrastructure-common/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/AbstractAddonInfrastructure.java
+++ b/infrastructures/infrastructure-common/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/AbstractAddonInfrastructure.java
@@ -614,6 +614,21 @@ public abstract class AbstractAddonInfrastructure extends InfrastructureManager 
         }
     }
 
+    protected long parseLongParameter(String parameterName, Object parameterValue) {
+        try {
+            // When no default value specified, the parameter is mandatory and should has an Long value.
+            return Long.parseLong(parseMandatoryParameter(parameterName, parameterValue));
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException(String.format("ERROR: The parameter [%s] should be specified with a numeric value.",
+                                                             parameterName));
+        }
+    }
+
+    protected long parseLongParameter(String parameterName, Object parameterValue, long defaultValue) {
+        String parameterStringValue = parseOptionalParameter(parameterValue, String.valueOf(defaultValue));
+        return parseLongParameter(parameterName, parameterStringValue);
+    }
+
     protected int parseIntParameter(String parameterName, Object parameterValue) {
         try {
             // When no default value specified, the parameter is mandatory and should has an Integer value.

--- a/infrastructures/infrastructure-common/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/AbstractAddonInfrastructure.java
+++ b/infrastructures/infrastructure-common/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/AbstractAddonInfrastructure.java
@@ -25,6 +25,8 @@
  */
 package org.ow2.proactive.resourcemanager.nodesource.infrastructure;
 
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 import java.security.KeyException;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -597,6 +599,16 @@ public abstract class AbstractAddonInfrastructure extends InfrastructureManager 
         logger.info(action + " - node sets are now: nodes per instance=" + nodesPerInstance +
                     ", number of removed nodes per instance=" + nbRemovedNodesPerInstance + ", free instances map=" +
                     instancesWithoutNodesMap);
+    }
+
+    protected String generateDefaultRMHostname() {
+        try {
+            // best effort, may not work for all machines
+            return InetAddress.getLocalHost().getCanonicalHostName();
+        } catch (UnknownHostException e) {
+            logger.warn(e);
+            return "localhost";
+        }
     }
 
     protected String parseMandatoryParameter(String parameterName, Object parameterValue) {

--- a/infrastructures/infrastructure-common/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/AbstractAddonInfrastructure.java
+++ b/infrastructures/infrastructure-common/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/AbstractAddonInfrastructure.java
@@ -629,6 +629,10 @@ public abstract class AbstractAddonInfrastructure extends InfrastructureManager 
         return parseIntParameter(parameterName, parameterStringValue);
     }
 
+    protected String parseMandatoryFileParameter(String parameterName, Object parameterValue) {
+        return parseMandatoryParameter(parameterName, parseFileParameter(parameterName, parameterValue));
+    }
+
     protected String parseFileParameter(String parameterName, Object parameterValue) {
         if (parameterValue instanceof byte[]) {
             return new String((byte[]) parameterValue);

--- a/infrastructures/infrastructure-common/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/AbstractAddonInfrastructure.java
+++ b/infrastructures/infrastructure-common/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/AbstractAddonInfrastructure.java
@@ -32,6 +32,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.log4j.Logger;
 import org.objectweb.proactive.core.ProActiveException;
 import org.objectweb.proactive.core.node.Node;
@@ -608,8 +609,12 @@ public abstract class AbstractAddonInfrastructure extends InfrastructureManager 
         }
     }
 
+    protected boolean parameterValueIsNotSpecified(Object parameterValue) {
+        return parameterValue == null || StringUtils.isBlank(parameterValue.toString());
+    }
+
     protected void checkRMHostname(String rmHostname) {
-        if (rmHostname == null) {
+        if (parameterValueIsNotSpecified(rmHostname)) {
             throw new IllegalArgumentException("The resource manager hostname must be specified");
         }
         if (rmHostname.contains("/")) {

--- a/infrastructures/infrastructure-common/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/util/LinuxInitScriptGenerator.java
+++ b/infrastructures/infrastructure-common/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/util/LinuxInitScriptGenerator.java
@@ -114,7 +114,7 @@ public class LinuxInitScriptGenerator {
         return "nohup " + javaCommand + javaProperties + "  &";
     }
 
-    public String generateDefaultIaasConnectorURL(String DefaultRMHostname) {
+    public static String generateDefaultIaasConnectorURL(String DefaultRMHostname) {
         // I return the requested value while taking into account the configuration parameters
         return nsConfig.getString(NSProperties.DEFAULT_PREFIX_CONNECTOR_IAAS_URL) + DefaultRMHostname +
                nsConfig.getString(NSProperties.DEFAULT_SUFFIX_CONNECTOR_IAAS_URL);

--- a/infrastructures/infrastructure-gce/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/GCEInfrastructure.java
+++ b/infrastructures/infrastructure-gce/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/GCEInfrastructure.java
@@ -233,7 +233,7 @@ public class GCEInfrastructure extends AbstractAddonInfrastructure {
         }
         // rmHostname
         parameterIndex++;
-        checkRMHostname(parameters[parameterIndex].toString());
+        parseHostnameParameter("rmHostname", parameters[parameterIndex].toString());
         // connectorIaasURL
         parameterIndex++;
         if (parameterValueIsNotSpecified(parameters[parameterIndex])) {

--- a/infrastructures/infrastructure-gce/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/GCEInfrastructure.java
+++ b/infrastructures/infrastructure-gce/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/GCEInfrastructure.java
@@ -161,10 +161,10 @@ public class GCEInfrastructure extends AbstractAddonInfrastructure {
     protected String rmHostname = generateDefaultRMHostname();
 
     @Configurable(description = "Connector-iaas URL", sectionSelector = 4, important = true)
-    protected String connectorIaasURL = linuxInitScriptGenerator.generateDefaultIaasConnectorURL(generateDefaultRMHostname());
+    protected String connectorIaasURL = LinuxInitScriptGenerator.generateDefaultIaasConnectorURL(generateDefaultRMHostname());
 
     @Configurable(description = "URL used to download the node jar on the virtual machine", sectionSelector = 4, important = true)
-    protected String nodeJarURL = LinuxInitScriptGenerator.generateDefaultNodeJarURL(rmHostname);
+    protected String nodeJarURL = LinuxInitScriptGenerator.generateDefaultNodeJarURL(generateDefaultRMHostname());
 
     @Configurable(description = "(optional) Additional Java command properties (e.g. \"-Dpropertyname=propertyvalue\")", sectionSelector = 5)
     protected String additionalProperties = "-Dproactive.useIPaddress=true";
@@ -433,15 +433,6 @@ public class GCEInfrastructure extends AbstractAddonInfrastructure {
     @Override
     public String toString() {
         return getDescription();
-    }
-
-    private String generateDefaultRMHostname() {
-        try {
-            return InetAddress.getLocalHost().getCanonicalHostName();
-        } catch (UnknownHostException e) {
-            logger.warn(e);
-            return "localhost";
-        }
     }
 
     @SuppressWarnings("unchecked")

--- a/infrastructures/infrastructure-openstack/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/OpenstackInfrastructure.java
+++ b/infrastructures/infrastructure-openstack/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/OpenstackInfrastructure.java
@@ -25,8 +25,6 @@
  */
 package org.ow2.proactive.resourcemanager.nodesource.infrastructure;
 
-import java.net.InetAddress;
-import java.net.UnknownHostException;
 import java.security.KeyException;
 import java.util.*;
 import java.util.concurrent.*;
@@ -114,13 +112,13 @@ public class OpenstackInfrastructure extends AbstractAddonInfrastructure {
     protected int numberOfNodesPerInstance = 1;
 
     @Configurable(description = "Connector-iaas URL", sectionSelector = 4, important = true)
-    protected String connectorIaasURL = linuxInitScriptGenerator.generateDefaultIaasConnectorURL(generateDefaultRMHostname());
+    protected String connectorIaasURL = LinuxInitScriptGenerator.generateDefaultIaasConnectorURL(generateDefaultRMHostname());
 
     @Configurable(description = "Resource Manager hostname or ip address", sectionSelector = 4, important = true)
     protected String rmHostname = generateDefaultRMHostname();
 
     @Configurable(description = "URL used to download the node jar on the instance", sectionSelector = 5, important = true)
-    protected String nodeJarURL = linuxInitScriptGenerator.generateDefaultNodeJarURL(rmHostname);
+    protected String nodeJarURL = LinuxInitScriptGenerator.generateDefaultNodeJarURL(generateDefaultRMHostname());
 
     @Configurable(description = "(optional) Additional Java command properties (e.g. \"-Dpropertyname=propertyvalue\")", sectionSelector = 5)
     protected String additionalProperties = "-Dproactive.useIPaddress=true";
@@ -298,16 +296,6 @@ public class OpenstackInfrastructure extends AbstractAddonInfrastructure {
     @Override
     public String toString() {
         return getDescription();
-    }
-
-    private String generateDefaultRMHostname() {
-        try {
-            // best effort, may not work for all machines
-            return InetAddress.getLocalHost().getCanonicalHostName();
-        } catch (UnknownHostException e) {
-            logger.warn(e);
-            return "localhost";
-        }
     }
 
     @Override

--- a/infrastructures/infrastructure-openstack/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/OpenstackInfrastructure.java
+++ b/infrastructures/infrastructure-openstack/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/OpenstackInfrastructure.java
@@ -104,7 +104,7 @@ public class OpenstackInfrastructure extends AbstractAddonInfrastructure {
     @Configurable(description = "Flavor type of OpenStack", sectionSelector = 3, important = true)
     protected String flavor = null;
 
-    @Configurable(description = "Public key name for Openstack instance", sectionSelector = 3)
+    @Configurable(description = "(optional) Public key name for Openstack instance", sectionSelector = 3)
     protected String publicKeyName = null;
 
     @Configurable(description = "Total (max) number of instances to create", sectionSelector = 2, important = true)
@@ -122,11 +122,40 @@ public class OpenstackInfrastructure extends AbstractAddonInfrastructure {
     @Configurable(description = "URL used to download the node jar on the instance", sectionSelector = 5, important = true)
     protected String nodeJarURL = linuxInitScriptGenerator.generateDefaultNodeJarURL(rmHostname);
 
-    @Configurable(description = "Additional Java command properties (e.g. \"-Dpropertyname=propertyvalue\")", sectionSelector = 5)
+    @Configurable(description = "(optional) Additional Java command properties (e.g. \"-Dpropertyname=propertyvalue\")", sectionSelector = 5)
     protected String additionalProperties = "-Dproactive.useIPaddress=true";
 
-    @Configurable(description = "Estimated startup time of the nodes (including the startup time of VMs)", sectionSelector = 5)
+    @Configurable(description = "(optional, default value: " + DEFAULT_NODES_INIT_DELAY +
+                                ") Estimated startup time of the nodes (including the startup time of VMs)", sectionSelector = 5)
     protected long nodesInitDelay = DEFAULT_NODES_INIT_DELAY;
+
+    // The index of the infrastructure configurable parameters.
+    protected enum Indexes {
+        USERNAME(0),
+        PASSWORD(1),
+        DOMAIN(2),
+        ENDPOINT(3),
+        SCOPE_PREFIX(4),
+        SCOPE_VALUE(5),
+        REGION(6),
+        IDENTITY_VERSION(7),
+        IMAGE(8),
+        FLAVOR(9),
+        PUBLIC_KEY_NAME(10),
+        NUMBER_OF_INSTANCES(11),
+        NUMBER_OF_NODES_PER_INSTANCE(12),
+        CONNECTOR_IAAS_URL(13),
+        RM_HOSTNAME(14),
+        NODE_JAR_URL(15),
+        ADDITIONAL_PROPERTIES(16),
+        NODES_INIT_DELAY(17);
+
+        protected int index;
+
+        Indexes(int index) {
+            this.index = index;
+        }
+    }
 
     /**
      * Dynamic policy parameters
@@ -162,104 +191,34 @@ public class OpenstackInfrastructure extends AbstractAddonInfrastructure {
     public void configure(Object... parameters) {
 
         logger.info("Validating parameters : " + java.util.Arrays.toString(parameters));
-        validate(parameters);
-
-        this.username = parameters[0].toString().trim();
-        this.password = parameters[1].toString().trim();
-        this.domain = parameters[2].toString().trim();
-        this.endpoint = parameters[3].toString().trim();
-        this.scopePrefix = parameters[4].toString().trim();
-        this.scopeValue = parameters[5].toString().trim();
-        this.region = parameters[6].toString().trim();
-        this.identityVersion = parameters[7].toString().trim();
-        this.image = parameters[8].toString().trim();
-        this.flavor = parameters[9].toString().trim();
-        this.publicKeyName = parameters[10].toString().trim();
-        this.numberOfInstances = Integer.parseInt(parameters[11].toString().trim());
-        this.numberOfNodesPerInstance = Integer.parseInt(parameters[12].toString().trim());
-        this.connectorIaasURL = parameters[13].toString().trim();
-        this.rmHostname = parameters[14].toString().trim();
-        this.nodeJarURL = parameters[15].toString().trim();
-        this.additionalProperties = parameters[16].toString().trim();
-        this.nodesInitDelay = Long.parseLong(parameters[17].toString().trim());
-
-        connectorIaasController = new ConnectorIaasController(connectorIaasURL, INFRASTRUCTURE_TYPE);
-    }
-
-    private void validate(Object[] parameters) {
-
         if (parameters == null || parameters.length < NUMBER_OF_PARAMETERS) {
             throw new IllegalArgumentException("Invalid parameters for Openstack Infrastructure creation");
         }
-        // username
-        if (parameterValueIsNotSpecified(parameters[0])) {
-            throw new IllegalArgumentException("Openstack username must be specified");
-        }
-        // password
-        if (parameterValueIsNotSpecified(parameters[1])) {
-            throw new IllegalArgumentException("Openstack password must be specified");
-        }
-        // domain
-        if (parameterValueIsNotSpecified(parameters[2])) {
-            throw new IllegalArgumentException("Openstack user domain must be specified");
-        }
-        // endpoint
-        if (parameterValueIsNotSpecified(parameters[3])) {
-            throw new IllegalArgumentException("Openstack endpoint must be specified");
-        }
-        // scopePrefix
-        if (parameterValueIsNotSpecified(parameters[4])) {
-            throw new IllegalArgumentException("Openstack scope prefix must be specified");
-        }
-        // scopeValue
-        if (parameterValueIsNotSpecified(parameters[5])) {
-            throw new IllegalArgumentException("Openstack scope value must be specified");
-        }
-        // region
-        if (parameterValueIsNotSpecified(parameters[6])) {
-            throw new IllegalArgumentException("Openstack region must be specified");
-        }
-        // identityVersion
-        if (parameterValueIsNotSpecified(parameters[7])) {
-            throw new IllegalArgumentException("Openstack identity version must be specified");
-        }
-        // image
-        if (parameterValueIsNotSpecified(parameters[8])) {
-            throw new IllegalArgumentException("Openstack image id must be specified");
-        }
-        // flavor
-        if (parameterValueIsNotSpecified(parameters[9])) {
-            throw new IllegalArgumentException("Openstack flavor must be specified");
-        }
-        // publicKeyName not mandatory
-        // numberOfInstances
-        if (parameterValueIsNotSpecified(parameters[11])) {
-            throw new IllegalArgumentException("The number of instances to create must be specified");
-        }
-        // numberOfNodesPerInstance
-        if (parameterValueIsNotSpecified(parameters[12])) {
-            throw new IllegalArgumentException("The number of nodes per instance to deploy must be specified");
-        }
-        // connectorIaasURL
-        if (parameterValueIsNotSpecified(parameters[13])) {
-            throw new IllegalArgumentException("The connector-iaas URL must be specified");
-        }
-        // rmHostname
-        if (parameterValueIsNotSpecified(parameters[14])) {
-            throw new IllegalArgumentException("RM host (hostname or IP address) must be specified");
-        }
-        // nodeJarURL
-        if (parameterValueIsNotSpecified(parameters[15])) {
-            throw new IllegalArgumentException("The URL to download 'node.jar' must be specified");
-        }
-        // additionalProperties
-        if (parameters[16] == null) {
-            parameters[16] = "";
-        }
-        // nodesInitDelay
-        if (parameterValueIsNotSpecified(parameters[17])) {
-            parameters[17] = DEFAULT_NODES_INIT_DELAY;
-        }
+
+        this.username = parseMandatoryParameter("username", parameters[Indexes.USERNAME.index]);
+        this.password = parseMandatoryParameter("password", parameters[Indexes.PASSWORD.index]);
+        this.domain = parseMandatoryParameter("domain", parameters[Indexes.DOMAIN.index]);
+        this.endpoint = parseMandatoryParameter("endpoint", parameters[Indexes.ENDPOINT.index]);
+        this.scopePrefix = parseMandatoryParameter("scopePrefix", parameters[Indexes.SCOPE_PREFIX.index]);
+        this.scopeValue = parseMandatoryParameter("scopeValue", parameters[Indexes.SCOPE_VALUE.index]);
+        this.region = parseMandatoryParameter("region", parameters[Indexes.REGION.index]);
+        this.identityVersion = parseMandatoryParameter("identityVersion", parameters[Indexes.IDENTITY_VERSION.index]);
+        this.image = parseMandatoryParameter("image", parameters[Indexes.IMAGE.index]);
+        this.flavor = parseMandatoryParameter("flavor", parameters[Indexes.FLAVOR.index]);
+        this.publicKeyName = parseOptionalParameter(parameters[Indexes.PUBLIC_KEY_NAME.index], "");
+        this.numberOfInstances = parseIntParameter("numberOfInstances", parameters[Indexes.NUMBER_OF_INSTANCES.index]);
+        this.numberOfNodesPerInstance = parseIntParameter("numberOfNodesPerInstance",
+                                                          parameters[Indexes.NUMBER_OF_NODES_PER_INSTANCE.index]);
+        this.connectorIaasURL = parseMandatoryParameter("connectorIaasURL",
+                                                        parameters[Indexes.CONNECTOR_IAAS_URL.index]);
+        this.rmHostname = parseMandatoryParameter("rmHostname", parameters[Indexes.RM_HOSTNAME.index]);
+        this.nodeJarURL = parseMandatoryParameter("nodeJarURL", parameters[Indexes.NODE_JAR_URL.index]);
+        this.additionalProperties = parseOptionalParameter(parameters[Indexes.ADDITIONAL_PROPERTIES.index], "");
+        this.nodesInitDelay = parseLongParameter("nodesInitDelay",
+                                                 parameters[Indexes.NODES_INIT_DELAY.index],
+                                                 DEFAULT_NODES_INIT_DELAY);
+
+        connectorIaasController = new ConnectorIaasController(connectorIaasURL, INFRASTRUCTURE_TYPE);
     }
 
     @Override

--- a/infrastructures/infrastructure-openstack/src/test/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/OpenstackInfrastructureTest.java
+++ b/infrastructures/infrastructure-openstack/src/test/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/OpenstackInfrastructureTest.java
@@ -102,15 +102,7 @@ public class OpenstackInfrastructureTest {
         assertThat(openstackInfrastructure.image, is(nullValue()));
         assertThat(openstackInfrastructure.numberOfInstances, is(1));
         assertThat(openstackInfrastructure.numberOfNodesPerInstance, is(1));
-        if (System.getProperty("os.name").contains("Windows")) {
-            assertThat(openstackInfrastructure.downloadCommand,
-                       is("powershell -command \"& { (New-Object Net.WebClient).DownloadFile('" +
-                          openstackInfrastructure.rmHostname + ":8080/rest/node.jar', 'node.jar') }\""));
-        } else {
-            assertThat(openstackInfrastructure.downloadCommand,
-                       is("wget -nv " + openstackInfrastructure.rmHostname + ":8080/rest/node.jar"));
-
-        }
+        assertThat(openstackInfrastructure.nodeJarURL, is(openstackInfrastructure.rmHostname + ":8080/rest/node.jar"));
         assertThat(openstackInfrastructure.additionalProperties, is("-Dproactive.useIPaddress=true"));
 
     }

--- a/infrastructures/infrastructure-vmware/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/VMWareInfrastructure.java
+++ b/infrastructures/infrastructure-vmware/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/VMWareInfrastructure.java
@@ -280,16 +280,6 @@ public class VMWareInfrastructure extends AbstractAddonInfrastructure {
         return getDescription();
     }
 
-    private String generateDefaultRMHostname() {
-        try {
-            // best effort, may not work for all machines
-            return InetAddress.getLocalHost().getCanonicalHostName();
-        } catch (UnknownHostException e) {
-            logger.warn(e);
-            return "localhost";
-        }
-    }
-
     private String generateDefaultDownloadCommand() {
         if (System.getProperty("os.name").contains("Windows")) {
             return "powershell -command \"& { (New-Object Net.WebClient).DownloadFile('http://" + this.rmHostname +


### PR DESCRIPTION
Fix:
- For most parameters of Infrastructure and Policy, **blank string value** (besides null) should also be considered as not specified. That is, it should either throw exception or be assigned with default value.
- mandatory parameters should be marked as **important**.
- change expired parameters (downloadCommand, rmHttpUrl) and pass to linuxInitScriptGenerator for **customizing node.jar url**.
  - OpenstackInfrastructure: downloadCommand -> nodeJarURL
  - AzureInfrastructure: downloadCommand -> nodeJarURL; rmHttpUrl -> rmHostname

Refactoring:
- combine parameters validating and assigning value to improve code readability
- add `parseMandatoryParameter` and `parseOptionalParameter` in `AbstractAddonInfrastructure` to facilitate validating and parsing parameters
- move duplicated `generateDefaultRMHostname` to `AbstractAddonInfrastructure`
