### PR TITLE
fix: infra param nodeJarUrl add http protocol (read from WebProperties)

### DIFF
--- a/infrastructures/infrastructure-aws-ec2/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/AWSEC2Infrastructure.java
+++ b/infrastructures/infrastructure-aws-ec2/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/AWSEC2Infrastructure.java
@@ -25,8 +25,6 @@
  */
 package org.ow2.proactive.resourcemanager.nodesource.infrastructure;
 
-import java.net.InetAddress;
-import java.net.UnknownHostException;
 import java.security.KeyException;
 import java.util.*;
 import java.util.AbstractMap.SimpleImmutableEntry;
@@ -156,13 +154,13 @@ public class AWSEC2Infrastructure extends AbstractAddonInfrastructure {
     @Configurable(description = "(optional) The subnet ID which is added to a specific Amazon VPC.", sectionSelector = 3)
     protected String subnetId = null;
 
-    @Configurable(description = "Resource Manager hostname or ip address (must be accessible from nodes)", sectionSelector = 4, important = true)
+    @Configurable(description = "Resource Manager hostname or ip address (must be accessible from nodes)", sectionSelector = 4)
     protected String rmHostname = generateDefaultRMHostname();
 
-    @Configurable(description = "Connector-iaas URL", sectionSelector = 4, important = true)
+    @Configurable(description = "Connector-iaas URL", sectionSelector = 4)
     protected String connectorIaasURL = LinuxInitScriptGenerator.generateDefaultIaasConnectorURL(generateDefaultRMHostname());
 
-    @Configurable(description = "URL used to download the node jar on the VM", sectionSelector = 4, important = true)
+    @Configurable(description = "URL used to download the node jar on the VM", sectionSelector = 4)
     protected String nodeJarURL = LinuxInitScriptGenerator.generateDefaultNodeJarURL(generateDefaultRMHostname());
 
     @Configurable(description = "(optional) Additional Java command properties (e.g. \"-Dpropertyname=propertyvalue\")", sectionSelector = 5)

--- a/infrastructures/infrastructure-aws-ec2/src/test/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/AWSEC2InfrastructureTest.java
+++ b/infrastructures/infrastructure-aws-ec2/src/test/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/AWSEC2InfrastructureTest.java
@@ -149,7 +149,8 @@ public class AWSEC2InfrastructureTest {
         assertThat(awsec2Infrastructure.rmHostname, is(not(nullValue())));
         assertThat(awsec2Infrastructure.connectorIaasURL,
                    is("http://" + awsec2Infrastructure.rmHostname + ":8080/connector-iaas"));
-        assertThat(awsec2Infrastructure.nodeJarURL, is(awsec2Infrastructure.rmHostname + ":8080/rest/node.jar"));
+        assertThat(awsec2Infrastructure.nodeJarURL,
+                   is("http://" + awsec2Infrastructure.rmHostname + ":8080/rest/node.jar"));
         assertThat(awsec2Infrastructure.additionalProperties, is(""));
     }
 

--- a/infrastructures/infrastructure-azure/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/AzureInfrastructure.java
+++ b/infrastructures/infrastructure-azure/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/AzureInfrastructure.java
@@ -203,10 +203,10 @@ public class AzureInfrastructure extends AbstractAddonInfrastructure {
     @Configurable(description = "Optional graph endpoint from specific Azure environment", sectionSelector = 2)
     protected String graphEndpoint = null;
 
-    @Configurable(description = "Resource manager hostname or ip address (must be accessible from nodes)", sectionSelector = 3, important = true)
+    @Configurable(description = "Resource manager hostname or ip address (must be accessible from nodes)", sectionSelector = 3)
     protected String rmHostname = generateDefaultRMHostname();
 
-    @Configurable(description = "Connector-iaas URL", sectionSelector = 3, important = true)
+    @Configurable(description = "Connector-iaas URL", sectionSelector = 3)
     protected String connectorIaasURL = LinuxInitScriptGenerator.generateDefaultIaasConnectorURL(generateDefaultRMHostname());
 
     @Configurable(description = "Image (name or key)", sectionSelector = 5, important = true)
@@ -243,7 +243,7 @@ public class AzureInfrastructure extends AbstractAddonInfrastructure {
     // The variable is not longer effectively used, but it's kept temporarily to facilitate future support of deploying nodes on windows os VM
     protected String downloadCommand = null;
 
-    @Configurable(description = "URL used to download the node jar on the VM", sectionSelector = 7, important = true)
+    @Configurable(description = "URL used to download the node jar on the VM", sectionSelector = 7)
     protected String nodeJarURL = LinuxInitScriptGenerator.generateDefaultNodeJarURL(generateDefaultRMHostname());
 
     @Configurable(description = "Optional network CIDR to attach with new VM(s) (by default: '10.0.0.0/24')", sectionSelector = 6)

--- a/infrastructures/infrastructure-common/build.gradle
+++ b/infrastructures/infrastructure-common/build.gradle
@@ -20,9 +20,15 @@ dependencies {
     compile 'org.json:json:20151123'
 
     compile "org.ow2.proactive:rm-server:${rmVersion}"
+    compile "org.ow2.proactive:common-http:${rmVersion}"
     compile "org.objectweb.proactive:programming-core:${programmingVersion}"
 
     testCompile 'junit:junit:4.12'
     testCompile 'org.hamcrest:hamcrest-junit:2.0.0.0'
     testCompile 'org.mockito:mockito-core:1.10.19'
+}
+
+configurations {
+    runtime.exclude module: "commons-logging"
+    runtime.exclude group: "log4j"
 }

--- a/infrastructures/infrastructure-common/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/util/LinuxInitScriptGenerator.java
+++ b/infrastructures/infrastructure-common/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/util/LinuxInitScriptGenerator.java
@@ -39,10 +39,13 @@ public class LinuxInitScriptGenerator {
 
     private static Configuration nsConfig;
 
+    private static WebPropertiesLoader webConfig;
+
     static {
         try {
             // load configuration manager with the NodeSource properties file
             nsConfig = NSProperties.loadConfig();
+            webConfig = new WebPropertiesLoader();
         } catch (ConfigurationException e) {
             logger.error("Exception when loading NodeSource properties", e);
             throw new RuntimeException(e);
@@ -114,10 +117,9 @@ public class LinuxInitScriptGenerator {
         return "nohup " + javaCommand + javaProperties + "  &";
     }
 
-    public static String generateDefaultIaasConnectorURL(String DefaultRMHostname) {
+    public static String generateDefaultIaasConnectorURL(String rmHostname) {
         // I return the requested value while taking into account the configuration parameters
-        return nsConfig.getString(NSProperties.DEFAULT_PREFIX_CONNECTOR_IAAS_URL) + DefaultRMHostname +
-               nsConfig.getString(NSProperties.DEFAULT_SUFFIX_CONNECTOR_IAAS_URL);
+        return generateDefaultBaseURL(rmHostname) + nsConfig.getString(NSProperties.DEFAULT_SUFFIX_CONNECTOR_IAAS_URL);
     }
 
     public static String generateDefaultDownloadCommand(String rmHostname) {
@@ -125,6 +127,10 @@ public class LinuxInitScriptGenerator {
     }
 
     public static String generateDefaultNodeJarURL(String rmHostname) {
-        return rmHostname + nsConfig.getString(NSProperties.DEFAULT_SUFFIX_RM_TO_NODEJAR_URL);
+        return generateDefaultBaseURL(rmHostname) + nsConfig.getString(NSProperties.DEFAULT_SUFFIX_RM_TO_NODEJAR_URL);
+    }
+
+    public static String generateDefaultBaseURL(String hostname) {
+        return webConfig.getHttpProtocol() + "://" + hostname + ":" + webConfig.getRestPort();
     }
 }

--- a/infrastructures/infrastructure-common/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/util/NSProperties.java
+++ b/infrastructures/infrastructure-common/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/util/NSProperties.java
@@ -59,8 +59,6 @@ public class NSProperties {
 
     public static final String DEFAULT_SUFFIX_CONNECTOR_IAAS_URL = "ns.default.suffix.connector.iaas.url";
 
-    public static final String DEFAULT_PREFIX_CONNECTOR_IAAS_URL = "ns.default.prefix.connector.iaas.url";
-
     public static final String DEFAULT_JYTHON_PATH = "ns.default.jython.path";
 
     /**

--- a/infrastructures/infrastructure-common/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/util/WebPropertiesLoader.java
+++ b/infrastructures/infrastructure-common/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/util/WebPropertiesLoader.java
@@ -1,0 +1,98 @@
+/*
+ * ProActive Parallel Suite(TM):
+ * The Open Source library for parallel and distributed
+ * Workflows & Scheduling, Orchestration, Cloud Automation
+ * and Big Data Analysis on Enterprise Grids & Clouds.
+ *
+ * Copyright (c) 2007 - 2017 ActiveEon
+ * Contact: contact@activeeon.com
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation: version 3 of
+ * the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ */
+package org.ow2.proactive.resourcemanager.nodesource.infrastructure.util;
+
+import org.ow2.proactive.scheduler.core.properties.PASchedulerProperties;
+import org.ow2.proactive.web.WebProperties;
+
+
+/**
+ * @author ActiveEon Team
+ * @since 19/02/20
+ */
+public class WebPropertiesLoader {
+
+    private final int DEFAULT_JETTY_HTTP_PORT = 8080;
+
+    private final int DEFAULT_JETTY_HTTPS_PORT = 8443;
+
+    private boolean httpsEnabled;
+
+    private String httpProtocol;
+
+    private int restPort;
+
+    public WebPropertiesLoader() {
+        initializeRestProperties();
+        httpsEnabled = WebProperties.WEB_HTTPS.getValueAsBoolean();
+        if (httpsEnabled) {
+            httpProtocol = "https";
+            restPort = getJettyHttpsPort();
+        } else {
+            httpProtocol = "http";
+            restPort = getJettyHttpPort();
+        }
+    }
+
+    public String getHttpProtocol() {
+        return httpProtocol;
+    }
+
+    public int getRestPort() {
+        return restPort;
+    }
+
+    private void initializeRestProperties() {
+        String schedulerHome = getSchedulerHome();
+        System.setProperty(WebProperties.REST_HOME.getKey(), schedulerHome);
+        WebProperties.load();
+        if (!schedulerHome.equals(WebProperties.REST_HOME.getValueAsString())) {
+            throw new IllegalStateException("Rest home directory could not be initialized");
+        }
+    }
+
+    private String getSchedulerHome() {
+        if (PASchedulerProperties.SCHEDULER_HOME.isSet()) {
+            return PASchedulerProperties.SCHEDULER_HOME.getValueAsString();
+        } else {
+            return ".";
+        }
+    }
+
+    private int getJettyHttpPort() {
+        if (WebProperties.WEB_HTTP_PORT.isSet()) {
+            return WebProperties.WEB_HTTP_PORT.getValueAsInt();
+        }
+        return DEFAULT_JETTY_HTTP_PORT;
+    }
+
+    public int getJettyHttpsPort() {
+        if (WebProperties.WEB_HTTPS_PORT.isSet()) {
+            return WebProperties.WEB_HTTPS_PORT.getValueAsInt();
+        }
+        return DEFAULT_JETTY_HTTPS_PORT;
+    }
+}

--- a/infrastructures/infrastructure-common/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/util/WebPropertiesLoader.java
+++ b/infrastructures/infrastructure-common/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/util/WebPropertiesLoader.java
@@ -25,7 +25,7 @@
  */
 package org.ow2.proactive.resourcemanager.nodesource.infrastructure.util;
 
-import org.ow2.proactive.scheduler.core.properties.PASchedulerProperties;
+import org.ow2.proactive.resourcemanager.core.properties.PAResourceManagerProperties;
 import org.ow2.proactive.web.WebProperties;
 
 
@@ -75,8 +75,8 @@ public class WebPropertiesLoader {
     }
 
     private String getSchedulerHome() {
-        if (PASchedulerProperties.SCHEDULER_HOME.isSet()) {
-            return PASchedulerProperties.SCHEDULER_HOME.getValueAsString();
+        if (PAResourceManagerProperties.RM_HOME.isSet()) {
+            return PAResourceManagerProperties.RM_HOME.getValueAsString();
         } else {
             return ".";
         }

--- a/infrastructures/infrastructure-common/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/util/WebPropertiesLoader.java
+++ b/infrastructures/infrastructure-common/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/util/WebPropertiesLoader.java
@@ -28,6 +28,8 @@ package org.ow2.proactive.resourcemanager.nodesource.infrastructure.util;
 import org.ow2.proactive.resourcemanager.core.properties.PAResourceManagerProperties;
 import org.ow2.proactive.web.WebProperties;
 
+import lombok.Getter;
+
 
 /**
  * @author ActiveEon Team
@@ -35,19 +37,19 @@ import org.ow2.proactive.web.WebProperties;
  */
 public class WebPropertiesLoader {
 
-    private final int DEFAULT_JETTY_HTTP_PORT = 8080;
+    private static final int DEFAULT_JETTY_HTTP_PORT = 8080;
 
-    private final int DEFAULT_JETTY_HTTPS_PORT = 8443;
+    private static final int DEFAULT_JETTY_HTTPS_PORT = 8443;
 
-    private boolean httpsEnabled;
-
+    @Getter
     private String httpProtocol;
 
+    @Getter
     private int restPort;
 
     public WebPropertiesLoader() {
         initializeRestProperties();
-        httpsEnabled = WebProperties.WEB_HTTPS.getValueAsBoolean();
+        boolean httpsEnabled = WebProperties.WEB_HTTPS.getValueAsBoolean();
         if (httpsEnabled) {
             httpProtocol = "https";
             restPort = getJettyHttpsPort();
@@ -55,14 +57,6 @@ public class WebPropertiesLoader {
             httpProtocol = "http";
             restPort = getJettyHttpPort();
         }
-    }
-
-    public String getHttpProtocol() {
-        return httpProtocol;
-    }
-
-    public int getRestPort() {
-        return restPort;
     }
 
     private void initializeRestProperties() {
@@ -89,7 +83,7 @@ public class WebPropertiesLoader {
         return DEFAULT_JETTY_HTTP_PORT;
     }
 
-    public int getJettyHttpsPort() {
+    private int getJettyHttpsPort() {
         if (WebProperties.WEB_HTTPS_PORT.isSet()) {
             return WebProperties.WEB_HTTPS_PORT.getValueAsInt();
         }

--- a/infrastructures/infrastructure-common/src/main/resources/NodeSource.properties
+++ b/infrastructures/infrastructure-common/src/main/resources/NodeSource.properties
@@ -4,7 +4,6 @@
 ns.jre.install = true
 ns.script.linux.jre.install.command = mkdir -p /tmp/node && cd /tmp/node && if ! type -p jre/bin/java; then wget -nv -N https://s3.amazonaws.com/ci-materials/Latest_jre/jre-8u131-linux-x64.tar.gz; tar -xf jre-8u131-linux-x64.tar.gz; mv  jre1.8.0_131/ jre;  fi
 ns.script.linux.java.command = jre/bin/java
-ns.default.suffix.rm.to.nodejar.url = :8080/rest/node.jar
-ns.default.suffix.connector.iaas.url = :8080/connector-iaas
-ns.default.prefix.connector.iaas.url = http://
+ns.default.suffix.rm.to.nodejar.url = /rest/node.jar
+ns.default.suffix.connector.iaas.url = /connector-iaas
 ns.default.jython.path = /tmp/node/lib/jython-standalone-2.7.0.jar/Lib

--- a/infrastructures/infrastructure-gce/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/GCEInfrastructure.java
+++ b/infrastructures/infrastructure-gce/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/GCEInfrastructure.java
@@ -25,8 +25,6 @@
  */
 package org.ow2.proactive.resourcemanager.nodesource.infrastructure;
 
-import java.net.InetAddress;
-import java.net.UnknownHostException;
 import java.security.KeyException;
 import java.util.*;
 import java.util.concurrent.Executors;
@@ -157,13 +155,13 @@ public class GCEInfrastructure extends AbstractAddonInfrastructure {
                                 ") The minimum number of CPU cores required for each virtual machine", sectionSelector = 3)
     protected int cores = DEFAULT_CORES;
 
-    @Configurable(description = "Resource manager hostname or ip address (must be accessible from nodes)", sectionSelector = 4, important = true)
+    @Configurable(description = "Resource manager hostname or ip address (must be accessible from nodes)", sectionSelector = 4)
     protected String rmHostname = generateDefaultRMHostname();
 
-    @Configurable(description = "Connector-iaas URL", sectionSelector = 4, important = true)
+    @Configurable(description = "Connector-iaas URL", sectionSelector = 4)
     protected String connectorIaasURL = LinuxInitScriptGenerator.generateDefaultIaasConnectorURL(generateDefaultRMHostname());
 
-    @Configurable(description = "URL used to download the node jar on the virtual machine", sectionSelector = 4, important = true)
+    @Configurable(description = "URL used to download the node jar on the virtual machine", sectionSelector = 4)
     protected String nodeJarURL = LinuxInitScriptGenerator.generateDefaultNodeJarURL(generateDefaultRMHostname());
 
     @Configurable(description = "(optional) Additional Java command properties (e.g. \"-Dpropertyname=propertyvalue\")", sectionSelector = 5)

--- a/infrastructures/infrastructure-gce/src/test/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/GCEInfrastructureTest.java
+++ b/infrastructures/infrastructure-gce/src/test/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/GCEInfrastructureTest.java
@@ -153,7 +153,7 @@ public class GCEInfrastructureTest {
         assertThat(gceInfrastructure.rmHostname, is(not(nullValue())));
         assertThat(gceInfrastructure.connectorIaasURL,
                    is("http://" + gceInfrastructure.rmHostname + ":8080/connector-iaas"));
-        assertThat(gceInfrastructure.nodeJarURL, is(gceInfrastructure.rmHostname + ":8080/rest/node.jar"));
+        assertThat(gceInfrastructure.nodeJarURL, is("http://" + gceInfrastructure.rmHostname + ":8080/rest/node.jar"));
         assertThat(gceInfrastructure.additionalProperties, is(not(nullValue())));
         assertThat(gceInfrastructure.image, is(not(nullValue())));
         assertThat(gceInfrastructure.region, is(not(nullValue())));

--- a/infrastructures/infrastructure-openstack/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/OpenstackInfrastructure.java
+++ b/infrastructures/infrastructure-openstack/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/OpenstackInfrastructure.java
@@ -111,13 +111,13 @@ public class OpenstackInfrastructure extends AbstractAddonInfrastructure {
     @Configurable(description = "Total nodes to create per instance", sectionSelector = 2, important = true)
     protected int numberOfNodesPerInstance = 1;
 
-    @Configurable(description = "Connector-iaas URL", sectionSelector = 4, important = true)
+    @Configurable(description = "Connector-iaas URL", sectionSelector = 4)
     protected String connectorIaasURL = LinuxInitScriptGenerator.generateDefaultIaasConnectorURL(generateDefaultRMHostname());
 
-    @Configurable(description = "Resource Manager hostname or ip address", sectionSelector = 4, important = true)
+    @Configurable(description = "Resource Manager hostname or ip address", sectionSelector = 4)
     protected String rmHostname = generateDefaultRMHostname();
 
-    @Configurable(description = "URL used to download the node jar on the instance", sectionSelector = 5, important = true)
+    @Configurable(description = "URL used to download the node jar on the instance", sectionSelector = 5)
     protected String nodeJarURL = LinuxInitScriptGenerator.generateDefaultNodeJarURL(generateDefaultRMHostname());
 
     @Configurable(description = "(optional) Additional Java command properties (e.g. \"-Dpropertyname=propertyvalue\")", sectionSelector = 5)

--- a/infrastructures/infrastructure-openstack/src/test/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/OpenstackInfrastructureTest.java
+++ b/infrastructures/infrastructure-openstack/src/test/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/OpenstackInfrastructureTest.java
@@ -102,7 +102,8 @@ public class OpenstackInfrastructureTest {
         assertThat(openstackInfrastructure.image, is(nullValue()));
         assertThat(openstackInfrastructure.numberOfInstances, is(1));
         assertThat(openstackInfrastructure.numberOfNodesPerInstance, is(1));
-        assertThat(openstackInfrastructure.nodeJarURL, is(openstackInfrastructure.rmHostname + ":8080/rest/node.jar"));
+        assertThat(openstackInfrastructure.nodeJarURL,
+                   is("http://" + openstackInfrastructure.rmHostname + ":8080/rest/node.jar"));
         assertThat(openstackInfrastructure.additionalProperties, is("-Dproactive.useIPaddress=true"));
 
     }

--- a/infrastructures/infrastructure-vmware/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/VMWareInfrastructure.java
+++ b/infrastructures/infrastructure-vmware/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/VMWareInfrastructure.java
@@ -25,8 +25,7 @@
  */
 package org.ow2.proactive.resourcemanager.nodesource.infrastructure;
 
-import java.net.InetAddress;
-import java.net.UnknownHostException;
+import java.util.Arrays;
 import java.util.Map;
 import java.util.Set;
 
@@ -97,7 +96,7 @@ public class VMWareInfrastructure extends AbstractAddonInfrastructure {
     @Override
     public void configure(Object... parameters) {
 
-        logger.info("Validating parameters : " + parameters);
+        logger.info("Validating parameters : " + Arrays.toString(parameters));
         validate(parameters);
 
         this.username = parameters[0].toString().trim();


### PR DESCRIPTION
- For the default connectorIaasUrl and nodeJarUrl, read http protocol and port from WebProperties.
- Change infrastructure parameters `rmHostname`, `connectorIaasURL`, and `nodeJarURL` to not important