### PR TITLE
AWSEC2Infra support acquireNodes through REST request

### DIFF
--- a/infrastructures/infrastructure-aws-ec2/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/AWSEC2CustomizableParameter.java
+++ b/infrastructures/infrastructure-aws-ec2/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/AWSEC2CustomizableParameter.java
@@ -1,0 +1,110 @@
+/*
+ * ProActive Parallel Suite(TM):
+ * The Open Source library for parallel and distributed
+ * Workflows & Scheduling, Orchestration, Cloud Automation
+ * and Big Data Analysis on Enterprise Grids & Clouds.
+ *
+ * Copyright (c) 2007 - 2017 ActiveEon
+ * Contact: contact@activeeon.com
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation: version 3 of
+ * the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ */
+package org.ow2.proactive.resourcemanager.nodesource.infrastructure;
+
+public class AWSEC2CustomizableParameter {
+
+    private String image;
+
+    private String vmUsername;
+
+    private String vmKeyPairName;
+
+    private String vmPrivateKey;
+
+    private int ram;
+
+    private int cores;
+
+    private String additionalProperties;
+
+    public AWSEC2CustomizableParameter(String image, String vmUsername, String vmKeyPairName, String vmPrivateKey,
+            int ram, int cores, String additionalProperties) {
+        this.image = image;
+        this.vmUsername = vmUsername;
+        this.vmKeyPairName = vmKeyPairName;
+        this.vmPrivateKey = vmPrivateKey;
+        this.ram = ram;
+        this.cores = cores;
+        this.additionalProperties = additionalProperties;
+    }
+
+    public String getImage() {
+        return image;
+    }
+
+    public void setImage(String image) {
+        this.image = image;
+    }
+
+    public String getVmUsername() {
+        return vmUsername;
+    }
+
+    public void setVmUsername(String vmUsername) {
+        this.vmUsername = vmUsername;
+    }
+
+    public String getVmKeyPairName() {
+        return vmKeyPairName;
+    }
+
+    public void setVmKeyPairName(String vmKeyPairName) {
+        this.vmKeyPairName = vmKeyPairName;
+    }
+
+    public String getVmPrivateKey() {
+        return vmPrivateKey;
+    }
+
+    public void setVmPrivateKey(String vmPrivateKey) {
+        this.vmPrivateKey = vmPrivateKey;
+    }
+
+    public int getRam() {
+        return ram;
+    }
+
+    public void setRam(int ram) {
+        this.ram = ram;
+    }
+
+    public int getCores() {
+        return cores;
+    }
+
+    public void setCores(int cores) {
+        this.cores = cores;
+    }
+
+    public String getAdditionalProperties() {
+        return additionalProperties;
+    }
+
+    public void setAdditionalProperties(String additionalProperties) {
+        this.additionalProperties = additionalProperties;
+    }
+}

--- a/infrastructures/infrastructure-common/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/model/NodeConfiguration.java
+++ b/infrastructures/infrastructure-common/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/model/NodeConfiguration.java
@@ -1,0 +1,108 @@
+/*
+ * ProActive Parallel Suite(TM):
+ * The Open Source library for parallel and distributed
+ * Workflows & Scheduling, Orchestration, Cloud Automation
+ * and Big Data Analysis on Enterprise Grids & Clouds.
+ *
+ * Copyright (c) 2007 - 2017 ActiveEon
+ * Contact: contact@activeeon.com
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation: version 3 of
+ * the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ */
+package org.ow2.proactive.resourcemanager.nodesource.infrastructure.model;
+
+import java.io.Serializable;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class NodeConfiguration implements Serializable {
+
+    private String image;
+
+    private String vmType;
+
+    private Integer numberOfCores;
+
+    private Integer amountOfMemory;
+
+    private VmCredentials credentials;
+
+    private Port[] portToOpens;
+
+    private String nodeTags;
+
+    public NodeConfiguration() {
+    }
+
+    public String getImage() {
+        return image;
+    }
+
+    public void setImage(String image) {
+        this.image = image;
+    }
+
+    public String getVmType() {
+        return vmType;
+    }
+
+    public void setVmType(String vmType) {
+        this.vmType = vmType;
+    }
+
+    public Integer getNumberOfCores() {
+        return numberOfCores;
+    }
+
+    public void setNumberOfCores(Integer numberOfCores) {
+        this.numberOfCores = numberOfCores;
+    }
+
+    public Integer getAmountOfMemory() {
+        return amountOfMemory;
+    }
+
+    public void setAmountOfMemory(Integer amountOfMemory) {
+        this.amountOfMemory = amountOfMemory;
+    }
+
+    public VmCredentials getCredentials() {
+        return credentials;
+    }
+
+    public void setCredentials(VmCredentials credentials) {
+        this.credentials = credentials;
+    }
+
+    public Port[] getPortToOpens() {
+        return portToOpens;
+    }
+
+    public void setPortToOpens(Port[] portToOpens) {
+        this.portToOpens = portToOpens;
+    }
+
+    public String getNodeTags() {
+        return nodeTags;
+    }
+
+    public void setNodeTags(String nodeTags) {
+        this.nodeTags = nodeTags;
+    }
+}

--- a/infrastructures/infrastructure-common/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/model/Port.java
+++ b/infrastructures/infrastructure-common/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/model/Port.java
@@ -1,0 +1,53 @@
+/*
+ * ProActive Parallel Suite(TM):
+ * The Open Source library for parallel and distributed
+ * Workflows & Scheduling, Orchestration, Cloud Automation
+ * and Big Data Analysis on Enterprise Grids & Clouds.
+ *
+ * Copyright (c) 2007 - 2017 ActiveEon
+ * Contact: contact@activeeon.com
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation: version 3 of
+ * the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ */
+package org.ow2.proactive.resourcemanager.nodesource.infrastructure.model;
+
+import java.io.Serializable;
+
+
+public class Port implements Serializable {
+
+    private Integer value;
+
+    public Port() {
+    }
+
+    public Port(Integer value) {
+        if (value >= 0 && value < 65565) {
+            this.value = value;
+        } else {
+            throw new IllegalArgumentException(String.format("Invalid port value provided: %d", value));
+        }
+    }
+
+    public Integer getValue() {
+        return value;
+    }
+
+    public void setValue(Integer value) {
+        this.value = value;
+    }
+}

--- a/infrastructures/infrastructure-common/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/model/VmCredentials.java
+++ b/infrastructures/infrastructure-common/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/model/VmCredentials.java
@@ -1,0 +1,85 @@
+/*
+ * ProActive Parallel Suite(TM):
+ * The Open Source library for parallel and distributed
+ * Workflows & Scheduling, Orchestration, Cloud Automation
+ * and Big Data Analysis on Enterprise Grids & Clouds.
+ *
+ * Copyright (c) 2007 - 2017 ActiveEon
+ * Contact: contact@activeeon.com
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation: version 3 of
+ * the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ */
+package org.ow2.proactive.resourcemanager.nodesource.infrastructure.model;
+
+import java.io.Serializable;
+
+
+public class VmCredentials implements Serializable {
+
+    private String vmUserName;
+
+    private String vmPassword;
+
+    private String vmPrivateKey;
+
+    private String vmPublicKey;
+
+    private String vmKeyPairName;
+
+    public VmCredentials() {
+    }
+
+    public String getVmUserName() {
+        return vmUserName;
+    }
+
+    public void setVmUserName(String vmUserName) {
+        this.vmUserName = vmUserName;
+    }
+
+    public String getVmPassword() {
+        return vmPassword;
+    }
+
+    public void setVmPassword(String vmPassword) {
+        this.vmPassword = vmPassword;
+    }
+
+    public String getVmPrivateKey() {
+        return vmPrivateKey;
+    }
+
+    public void setVmPrivateKey(String vmPrivateKey) {
+        this.vmPrivateKey = vmPrivateKey;
+    }
+
+    public String getVmPublicKey() {
+        return vmPublicKey;
+    }
+
+    public void setVmPublicKey(String vmPublicKey) {
+        this.vmPublicKey = vmPublicKey;
+    }
+
+    public String getVmKeyPairName() {
+        return vmKeyPairName;
+    }
+
+    public void setVmKeyPairName(String vmKeyPairName) {
+        this.vmKeyPairName = vmKeyPairName;
+    }
+}


### PR DESCRIPTION
- add the timeout for acquiring the lock, so that the concurrent request is not directly ignored. (When the dynamic policy call the old acquireNodes func without timeout, timeout is set to 0, so its previous behavior is kept.)
- acquireNodes based on specific node configuration. Now the user can acquire new nodes with specific configuration like image, ram etc.
- support setting node tags in the additionalProperties.