### PR TITLE
AWSEC2Infrastructure: support spot instances, create instances async and better handling errors

### DIFF
--- a/infrastructures/infrastructure-aws-ec2/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/AWSEC2Infrastructure.java
+++ b/infrastructures/infrastructure-aws-ec2/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/AWSEC2Infrastructure.java
@@ -106,7 +106,8 @@ public class AWSEC2Infrastructure extends AbstractAddonInfrastructure {
         NODE_JAR_URL(14),
         ADDITIONAL_PROPERTIES(15),
         NODE_TIMEOUT(16),
-        STARTUP_SCRIPT(17);
+        STARTUP_SCRIPT(17),
+        SPOT_PRICE(18);
 
         protected int index;
 
@@ -149,10 +150,6 @@ public class AWSEC2Infrastructure extends AbstractAddonInfrastructure {
                                 DEFAULT_CORES + ")", sectionSelector = 3, important = true)
     protected int cores = DEFAULT_CORES;
 
-    // TODO disable to configure the parameter spotPrice for the moment, because we don't yet have a checking mechanism for it now, but it may cause the RM portal blocked (hanging in createInstance).
-    //    @Configurable(description = "(optional) The maximum price that you are willing to pay per hour per instance (your bid price)")
-    protected String spotPrice = "";
-
     @Configurable(description = "The ids(s) of the security group(s) for VMs, spearated by comma in case of multiple ids. (optional)", sectionSelector = 3)
     protected String securityGroupIds = null;
 
@@ -177,6 +174,10 @@ public class AWSEC2Infrastructure extends AbstractAddonInfrastructure {
 
     @Configurable(textArea = true, description = "VM startup script to launch the ProActive nodes (optional). Please refer to the documentation for full description.", sectionSelector = 5)
     protected String startupScript = initScriptGenerator.getDefaultLinuxStartupScript();
+
+    // TODO disable to configure the parameter spotPrice for the moment, because we don't yet have a checking mechanism for it now, but it may cause the RM portal blocked (hanging in createInstance).
+    @Configurable(description = "(optional) The maximum price that you are willing to pay per hour per instance (your bid price)", sectionSelector = 3)
+    protected String spotPrice = "";
 
     /**
      * Key to retrieve the key pair used to deploy the infrastructure
@@ -214,7 +215,7 @@ public class AWSEC2Infrastructure extends AbstractAddonInfrastructure {
         this.ram = parseIntParameter("ram", parameters[Indexes.RAM.index], DEFAULT_RAM);
         this.cores = parseIntParameter("cores", parameters[Indexes.CORES.index], DEFAULT_CORES);
         //        TODO disable to configure the parameter spotPrice for the moment
-        //        this.spotPrice = parameters[parameterIndex++].toString().trim();
+        this.spotPrice = parameters[Indexes.SPOT_PRICE.index].toString().trim();
         this.securityGroupIds = parseOptionalParameter(parameters[Indexes.SECURITY_GROUP_IDS.index]);
         this.subnetId = parseOptionalParameter(parameters[Indexes.SUBNET_ID.index]);
         this.rmHostname = parseHostnameParameter("rmHostname", parameters[Indexes.RM_HOSTNAME.index]);

--- a/infrastructures/infrastructure-aws-ec2/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/AWSEC2Infrastructure.java
+++ b/infrastructures/infrastructure-aws-ec2/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/AWSEC2Infrastructure.java
@@ -175,8 +175,7 @@ public class AWSEC2Infrastructure extends AbstractAddonInfrastructure {
     @Configurable(textArea = true, description = "VM startup script to launch the ProActive nodes (optional). Please refer to the documentation for full description.", sectionSelector = 5)
     protected String startupScript = initScriptGenerator.getDefaultLinuxStartupScript();
 
-    // TODO disable to configure the parameter spotPrice for the moment, because we don't yet have a checking mechanism for it now, but it may cause the RM portal blocked (hanging in createInstance).
-    @Configurable(description = "(optional) The maximum price that you are willing to pay per hour per instance (your bid price)", sectionSelector = 3)
+    @Configurable(description = "(optional) The maximum price that you are willing to pay per hour per instance (your bid price), when the spot price is too low to be satisfied within the node-running timeout, the node source deployment will be failed and the related spot requests will be cancelled.", sectionSelector = 3)
     protected String spotPrice = "";
 
     /**

--- a/infrastructures/infrastructure-aws-ec2/src/test/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/AWSEC2InfrastructureTest.java
+++ b/infrastructures/infrastructure-aws-ec2/src/test/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/AWSEC2InfrastructureTest.java
@@ -172,7 +172,6 @@ public class AWSEC2InfrastructureTest {
                                        VM_PRIVATE_KEY,
                                        RAM,
                                        CORES,
-                                       //                                       SPOT_PRICE,
                                        SECURITY_GROUP_NAMES,
                                        SUBNET_ID,
                                        RM_HOSTNAME,
@@ -180,7 +179,8 @@ public class AWSEC2InfrastructureTest {
                                        NODE_JAR_URL,
                                        ADDITIONAL_PROPERTIES,
                                        NODE_TIMEOUT,
-                                       STARTUP_SCRIPT);
+                                       STARTUP_SCRIPT,
+                                       SPOT_PRICE);
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -193,7 +193,6 @@ public class AWSEC2InfrastructureTest {
                                        VM_PRIVATE_KEY,
                                        RAM,
                                        CORES,
-                                       //                                       SPOT_PRICE,
                                        SECURITY_GROUP_NAMES,
                                        SUBNET_ID,
                                        RM_HOSTNAME,
@@ -201,7 +200,8 @@ public class AWSEC2InfrastructureTest {
                                        NODE_JAR_URL,
                                        ADDITIONAL_PROPERTIES,
                                        NODE_TIMEOUT,
-                                       STARTUP_SCRIPT);
+                                       STARTUP_SCRIPT,
+                                       SPOT_PRICE);
     }
 
     @Test
@@ -216,7 +216,6 @@ public class AWSEC2InfrastructureTest {
                                        VM_PRIVATE_KEY,
                                        RAM,
                                        CORES,
-                                       //                                       SPOT_PRICE,
                                        SECURITY_GROUP_NAMES,
                                        SUBNET_ID,
                                        RM_HOSTNAME,
@@ -224,7 +223,8 @@ public class AWSEC2InfrastructureTest {
                                        NODE_JAR_URL,
                                        ADDITIONAL_PROPERTIES,
                                        NODE_TIMEOUT,
-                                       STARTUP_SCRIPT);
+                                       STARTUP_SCRIPT,
+                                       SPOT_PRICE);
 
         awsec2Infrastructure.connectorIaasController = connectorIaasController;
 
@@ -323,7 +323,6 @@ public class AWSEC2InfrastructureTest {
                                        VM_PRIVATE_KEY,
                                        RAM,
                                        CORES,
-                                       //                                       SPOT_PRICE,
                                        SECURITY_GROUP_NAMES,
                                        SUBNET_ID,
                                        RM_HOSTNAME,
@@ -331,7 +330,8 @@ public class AWSEC2InfrastructureTest {
                                        NODE_JAR_URL,
                                        ADDITIONAL_PROPERTIES,
                                        NODE_TIMEOUT,
-                                       STARTUP_SCRIPT);
+                                       STARTUP_SCRIPT,
+                                       SPOT_PRICE);
 
         awsec2Infrastructure.connectorIaasController = connectorIaasController;
 
@@ -433,7 +433,6 @@ public class AWSEC2InfrastructureTest {
                                        VM_PRIVATE_KEY,
                                        RAM,
                                        CORES,
-                                       //                                       SPOT_PRICE,
                                        SECURITY_GROUP_NAMES,
                                        SUBNET_ID,
                                        RM_HOSTNAME,
@@ -441,7 +440,8 @@ public class AWSEC2InfrastructureTest {
                                        NODE_JAR_URL,
                                        ADDITIONAL_PROPERTIES,
                                        NODE_TIMEOUT,
-                                       STARTUP_SCRIPT);
+                                       STARTUP_SCRIPT,
+                                       SPOT_PRICE);
 
         awsec2Infrastructure.connectorIaasController = connectorIaasController;
 
@@ -478,7 +478,6 @@ public class AWSEC2InfrastructureTest {
                                        VM_PRIVATE_KEY,
                                        RAM,
                                        CORES,
-                                       //                                       SPOT_PRICE,
                                        SECURITY_GROUP_NAMES,
                                        SUBNET_ID,
                                        RM_HOSTNAME,
@@ -486,7 +485,8 @@ public class AWSEC2InfrastructureTest {
                                        NODE_JAR_URL,
                                        ADDITIONAL_PROPERTIES,
                                        NODE_TIMEOUT,
-                                       STARTUP_SCRIPT);
+                                       STARTUP_SCRIPT,
+                                       SPOT_PRICE);
 
         awsec2Infrastructure.connectorIaasController = connectorIaasController;
 

--- a/infrastructures/infrastructure-common/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/InstanceNotCreatedException.java
+++ b/infrastructures/infrastructure-common/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/InstanceNotCreatedException.java
@@ -1,0 +1,44 @@
+/*
+ * ProActive Parallel Suite(TM):
+ * The Open Source library for parallel and distributed
+ * Workflows & Scheduling, Orchestration, Cloud Automation
+ * and Big Data Analysis on Enterprise Grids & Clouds.
+ *
+ * Copyright (c) 2007 - 2017 ActiveEon
+ * Contact: contact@activeeon.com
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation: version 3 of
+ * the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ */
+package org.ow2.proactive.resourcemanager.nodesource.infrastructure;
+
+public class InstanceNotCreatedException extends RuntimeException {
+    public InstanceNotCreatedException() {
+        super();
+    }
+
+    public InstanceNotCreatedException(String s) {
+        super(s);
+    }
+
+    public InstanceNotCreatedException(String s, Throwable throwable) {
+        super(s, throwable);
+    }
+
+    public InstanceNotCreatedException(Throwable throwable) {
+        super(throwable);
+    }
+}


### PR DESCRIPTION
- Add parameter spotPrice in AWSEC2Infrastructure to support spot instances; 
- make creating instances completely asynchronous; 
- handling error during creating instances.