### PR TITLE
Fix log4j configuration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -121,10 +121,18 @@ configure(javaSubprojects) {
         shadowJar
 
         runtime.extendsFrom = [compile]
-        runtime.exclude module: 'rm-server'
-        runtime.exclude module: 'programming-core'
-        runtime.exclude module: 'guava'
-        runtime.exclude module: 'log4j'
+        runtime.exclude group: 'org.ow2.proactive', module: 'common-api'
+        runtime.exclude group: 'org.ow2.proactive', module: 'rm-server'
+        runtime.exclude group: 'org.objectweb.proactive', module: 'programming-core'
+        runtime.exclude group: 'com.google.guava', module: 'guava'
+        runtime.exclude group: 'commons-logging', module: 'commons-logging'
+        runtime.exclude group: 'org.apache', module: 'log4j'
+        runtime.exclude group: 'log4j', module: 'apache-log4j-extras'
+        runtime.exclude group: 'ch.qos.reload4j', module: 'reload4j'
+        runtime.exclude group: 'org.slf4j', module: 'slf4j-api'
+        runtime.exclude group: 'org.slf4j', module: 'slf4j-simple'
+        runtime.exclude group: 'org.slf4j', module: 'slf4j-log4j12'
+        runtime.exclude group: 'org.slf4j', module: 'slf4j-reload4j'
 
         testRuntime.extendsFrom = [testCompile]
     }

--- a/infrastructures/infrastructure-aws-ec2/build.gradle
+++ b/infrastructures/infrastructure-aws-ec2/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'com.github.johnrengelman.shadow'
 
 shadowJar {
     zip64 true
-    // note: in order to see packaged libraries versions in META-INF/maven, uncomment the following two lines
+    // note: in order to see packaged libraries versions in META-INF/maven, comment the following two lines
     exclude '**/pom.xml'
     exclude '**/pom.properties'
 }
@@ -27,12 +27,19 @@ configurations {
     shadowJar
 
     runtime.extendsFrom = [compile]
-    // exclude modules to prevent class loader LinkageError issues
-    runtime.exclude module: 'common-api'
-    runtime.exclude module: 'rm-server'
-    runtime.exclude module: 'programming-core'
-    runtime.exclude module: 'guava'
-    runtime.exclude module: 'log4j'
+    // exclude modules to prevent class loader LinkageError or log4j configuration issues
+    runtime.exclude group: 'org.ow2.proactive', module: 'common-api'
+    runtime.exclude group: 'org.ow2.proactive', module: 'rm-server'
+    runtime.exclude group: 'org.oobjectweb.proactive', module: 'programming-core'
+    runtime.exclude group: 'com.google.guava', module: 'guava'
+    runtime.exclude group: 'commons-logging', module: 'commons-logging'
+    runtime.exclude group: 'org.apache', module: 'log4j'
+    runtime.exclude group: 'log4j', module: 'apache-log4j-extras'
+    runtime.exclude group: 'ch.qos.reload4j', module: 'reload4j'
+    runtime.exclude group: 'org.slf4j', module: 'slf4j-api'
+    runtime.exclude group: 'org.slf4j', module: 'slf4j-simple'
+    runtime.exclude group: 'org.slf4j', module: 'slf4j-log4j12'
+    runtime.exclude group: 'org.slf4j', module: 'slf4j-reload4j'
 
     testRuntime.extendsFrom = [testCompile]
 }

--- a/infrastructures/infrastructure-azure/build.gradle
+++ b/infrastructures/infrastructure-azure/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'com.github.johnrengelman.shadow'
 
 shadowJar {
     zip64 true
-    // note: in order to see packaged libraries versions in META-INF/maven, uncomment the following two lines
+    // note: in order to see packaged libraries versions in META-INF/maven, comment the following two lines
     exclude '**/pom.xml'
     exclude '**/pom.properties'
 }
@@ -28,17 +28,19 @@ configurations {
     shadowJar
 
     runtime.extendsFrom = [compile]
-    // exclude modules to prevent class loader LinkageError issues
-    runtime.exclude module: 'common-api'
-    runtime.exclude module: 'rm-server'
-    runtime.exclude module: 'programming-core'
-    runtime.exclude module: 'guava'
-    runtime.exclude module: 'log4j'
-    runtime.exclude module: 'reload4j'
-    runtime.exclude module: 'slf4j-api'
-    runtime.exclude module: 'slf4j-simple'
-    runtime.exclude module: 'slf4j-log4j12'
-    runtime.exclude module: 'slf4j-reload4j'
+    // exclude modules to prevent class loader LinkageError or log4j configuration issues
+    runtime.exclude group: 'org.ow2.proactive', module: 'common-api'
+    runtime.exclude group: 'org.ow2.proactive', module: 'rm-server'
+    runtime.exclude group: 'org.oobjectweb.proactive', module: 'programming-core'
+    runtime.exclude group: 'com.google.guava', module: 'guava'
+    runtime.exclude group: 'commons-logging', module: 'commons-logging'
+    runtime.exclude group: 'org.apache', module: 'log4j'
+    runtime.exclude group: 'log4j', module: 'apache-log4j-extras'
+    runtime.exclude group: 'ch.qos.reload4j', module: 'reload4j'
+    runtime.exclude group: 'org.slf4j', module: 'slf4j-api'
+    runtime.exclude group: 'org.slf4j', module: 'slf4j-simple'
+    runtime.exclude group: 'org.slf4j', module: 'slf4j-log4j12'
+    runtime.exclude group: 'org.slf4j', module: 'slf4j-reload4j'
 
     testRuntime.extendsFrom = [testCompile]
 }

--- a/infrastructures/infrastructure-common/build.gradle
+++ b/infrastructures/infrastructure-common/build.gradle
@@ -34,6 +34,11 @@ dependencies {
 }
 
 configurations {
-    runtime.exclude module: "commons-logging"
-    runtime.exclude group: "log4j"
+    runtime.exclude group: 'commons-logging', module: 'commons-logging'
+    runtime.exclude group: 'org.apache', module: 'log4j'
+    runtime.exclude group: 'ch.qos.reload4j', module: 'reload4j'
+    runtime.exclude group: 'org.slf4j', module: 'slf4j-api'
+    runtime.exclude group: 'org.slf4j', module: 'slf4j-simple'
+    runtime.exclude group: 'org.slf4j', module: 'slf4j-log4j12'
+    runtime.exclude group: 'org.slf4j', module: 'slf4j-reload4j'
 }

--- a/infrastructures/infrastructure-gce/build.gradle
+++ b/infrastructures/infrastructure-gce/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'com.github.johnrengelman.shadow'
 
 shadowJar {
     zip64 true
-    // note: in order to see packaged libraries versions in META-INF/maven, uncomment the following two lines
+    // note: in order to see packaged libraries versions in META-INF/maven, comment the following two lines
     exclude '**/pom.xml'
     exclude '**/pom.properties'
 }
@@ -28,12 +28,19 @@ configurations {
     shadowJar
 
     runtime.extendsFrom = [compile]
-    // exclude modules to prevent class loader LinkageError issues
-    runtime.exclude module: 'common-api'
-    runtime.exclude module: 'rm-server'
-    runtime.exclude module: 'programming-core'
-    runtime.exclude module: 'guava'
-    runtime.exclude module: 'log4j'
+    // exclude modules to prevent class loader LinkageError or log4j configuration issues
+    runtime.exclude group: 'org.ow2.proactive', module: 'common-api'
+    runtime.exclude group: 'org.ow2.proactive', module: 'rm-server'
+    runtime.exclude group: 'org.oobjectweb.proactive', module: 'programming-core'
+    runtime.exclude group: 'com.google.guava', module: 'guava'
+    runtime.exclude group: 'commons-logging', module: 'commons-logging'
+    runtime.exclude group: 'org.apache', module: 'log4j'
+    runtime.exclude group: 'log4j', module: 'apache-log4j-extras'
+    runtime.exclude group: 'ch.qos.reload4j', module: 'reload4j'
+    runtime.exclude group: 'org.slf4j', module: 'slf4j-api'
+    runtime.exclude group: 'org.slf4j', module: 'slf4j-simple'
+    runtime.exclude group: 'org.slf4j', module: 'slf4j-log4j12'
+    runtime.exclude group: 'org.slf4j', module: 'slf4j-reload4j'
 
     testRuntime.extendsFrom = [testCompile]
 }

--- a/infrastructures/infrastructure-openstack/build.gradle
+++ b/infrastructures/infrastructure-openstack/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'com.github.johnrengelman.shadow'
 
 shadowJar {
     zip64 true
-    // note: in order to see packaged libraries versions in META-INF/maven, uncomment the following two lines
+    // note: in order to see packaged libraries versions in META-INF/maven, comment the following two lines
     exclude '**/pom.xml'
     exclude '**/pom.properties'
 }
@@ -27,12 +27,19 @@ configurations {
     shadowJar
 
     runtime.extendsFrom = [compile]
-    // exclude modules to prevent class loader LinkageError issues
-    runtime.exclude module: 'common-api'
-    runtime.exclude module: 'rm-server'
-    runtime.exclude module: 'programming-core'
-    runtime.exclude module: 'guava'
-    runtime.exclude module: 'log4j'
+    // exclude modules to prevent class loader LinkageError or log4j configuration issues
+    runtime.exclude group: 'org.ow2.proactive', module: 'common-api'
+    runtime.exclude group: 'org.ow2.proactive', module: 'rm-server'
+    runtime.exclude group: 'org.oobjectweb.proactive', module: 'programming-core'
+    runtime.exclude group: 'com.google.guava', module: 'guava'
+    runtime.exclude group: 'commons-logging', module: 'commons-logging'
+    runtime.exclude group: 'org.apache', module: 'log4j'
+    runtime.exclude group: 'log4j', module: 'apache-log4j-extras'
+    runtime.exclude group: 'ch.qos.reload4j', module: 'reload4j'
+    runtime.exclude group: 'org.slf4j', module: 'slf4j-api'
+    runtime.exclude group: 'org.slf4j', module: 'slf4j-simple'
+    runtime.exclude group: 'org.slf4j', module: 'slf4j-log4j12'
+    runtime.exclude group: 'org.slf4j', module: 'slf4j-reload4j'
 
     testRuntime.extendsFrom = [testCompile]
 }

--- a/infrastructures/infrastructure-vmware/build.gradle
+++ b/infrastructures/infrastructure-vmware/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'com.github.johnrengelman.shadow'
 
 shadowJar {
     zip64 true
-    // note: in order to see packaged libraries versions in META-INF/maven, uncomment the following two lines
+    // note: in order to see packaged libraries versions in META-INF/maven, comment the following two lines
     exclude '**/pom.xml'
     exclude '**/pom.properties'
 }
@@ -27,12 +27,19 @@ configurations {
     shadowJar
 
     runtime.extendsFrom = [compile]
-    // exclude modules to prevent class loader LinkageError issues
-    runtime.exclude module: 'common-api'
-    runtime.exclude module: 'rm-server'
-    runtime.exclude module: 'programming-core'
-    runtime.exclude module: 'guava'
-    runtime.exclude module: 'log4j'
+    // exclude modules to prevent class loader LinkageError or log4j configuration issues
+    runtime.exclude group: 'org.ow2.proactive', module: 'common-api'
+    runtime.exclude group: 'org.ow2.proactive', module: 'rm-server'
+    runtime.exclude group: 'org.objectweb.proactive', module: 'programming-core'
+    runtime.exclude group: 'com.google.guava', module: 'guava'
+    runtime.exclude group: 'commons-logging', module: 'commons-logging'
+    runtime.exclude group: 'org.apache', module: 'log4j'
+    runtime.exclude group: 'log4j', module: 'apache-log4j-extras'
+    runtime.exclude group: 'ch.qos.reload4j', module: 'reload4j'
+    runtime.exclude group: 'org.slf4j', module: 'slf4j-api'
+    runtime.exclude group: 'org.slf4j', module: 'slf4j-simple'
+    runtime.exclude group: 'org.slf4j', module: 'slf4j-log4j12'
+    runtime.exclude group: 'org.slf4j', module: 'slf4j-reload4j'
 
     testRuntime.extendsFrom = [testCompile]
 }


### PR DESCRIPTION
Exclude from shadowJar all log4j jars to let node sources load their log4j configuration from the parent system class loader